### PR TITLE
Make sure all resource links have trailing slash, and document this requirement.

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -22,7 +22,8 @@ tilbyr.
 
 Dette gjøres med ressurslenker og relasjonslenker som inneholder
 beskrivelse av ressursen med eksempler på forespørsler, resultat og
-statuskoder.
+statuskoder. Alle slike ressurslenker og relasjonslenker har
+avsluttende skråstrek.
 
 ![](./media/uml-klasse-http-metoder.png)
 
@@ -50,19 +51,19 @@ Content-Type: application/vnd.noark5-v4+json
     "_links": [
         {
             "href": "http://localhost:49708/api/arkivstruktur",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur"
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/"
         },
         {
             "href": "http://localhost:49708/api/sakarkiv",
-            "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv"
+            "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/"
         }
     ]
 }
 ```
 
 Eksempelet viser at denne arkivkjernen støtter arkivstruktur
-(http://rel.kxml.no/noark5/v4/api/arkivstruktur) og sakarkiv
-(http://rel.kxml.no/noark5/v4/api/sakarkiv).
+(http://rel.kxml.no/noark5/v4/api/arkivstruktur/) og sakarkiv
+(http://rel.kxml.no/noark5/v4/api/sakarkiv/).
 Ved å følge **href** til disse relasjonsnøkler vil tilgjengelige ressurser
 innen disse områder annonseres på samme måte.
 
@@ -95,7 +96,7 @@ Content-Type: application/vnd.noark5-v4+xml
     xmlns="http://www.kxml.no/rest/1.0">
     <Links>
         <link>
-            <rel>http://rel.kxml.no/noark5/v4/api/arkivstruktur</rel>
+            <rel>http://rel.kxml.no/noark5/v4/api/arkivstruktur/</rel>
             <href>http://localhost:49708/api/arkivstruktur</href>
             <type sxi:nil="true" />
             <deprecation xsi:nil="true" />
@@ -103,7 +104,7 @@ Content-Type: application/vnd.noark5-v4+xml
             <title xsi:nil="true" />
         </link>
         <link>
-            <rel>http://rel.kxml.no/noark5/v4/api/sakarkiv</rel>
+            <rel>http://rel.kxml.no/noark5/v4/api/sakarkiv/</rel>
             <href>http://localhost:49708/api/sakarkiv</href>
             <type sxi:nil="true" />
             <deprecation xsi:nil="true" />
@@ -124,8 +125,8 @@ relevant for denne relasjonsnøkkelen.
 
 | Relasjonsnøkkel (rel)                          | Beskrivelse                                            |
 | ---------------------------------------------- | ------------------------------------------------------ |
-| http://rel.kxml.no/noark5/v4/api/arkivstruktur | Arkivkjerne støtter konformitetsnivå 1 arkivstruktur   |
-| http://rel.kxml.no/noark5/v4/api/sakarkiv      | Arkivkjerne støtter konformitetsnivå for sakarkiv (2a) |
+| http://rel.kxml.no/noark5/v4/api/arkivstruktur/ | Arkivkjerne støtter konformitetsnivå 1 arkivstruktur   |
+| http://rel.kxml.no/noark5/v4/api/sakarkiv/      | Arkivkjerne støtter konformitetsnivå for sakarkiv (2a) |
 
 Relasjonsnøkler under de forskjellige konformitetsnivå listes ut i
 kapittel 7 sammen med beskrivelse av klasser.
@@ -156,12 +157,12 @@ lister med data bør støtte søk og filtrering.
     "_links": [
         {
             "href": "http://localhost:49708/api/arkivstruktur/arkiv{?$filter&$orderby&$top&$skip&$search}",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/arkiv",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/arkiv/",
             "templated": true
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/ny-arkivskaper",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/ny-arkivskaper",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/ny-arkivskaper/",
             "templated": false
         },
 ```
@@ -383,12 +384,12 @@ objekt i databasen, og er derfor uten «self»-relasjon.
     "_links": [
         {
             "href": "http://localhost:49708/api/kodelister/Dokumentmedium{?$filter&$orderby&$top&$skip}",
-            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/dokumentmedium",
+            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/dokumentmedium/",
             "templated": true
         },
         {
             "href": "http://localhost:49708/api/kodelister/Mapetype{?$filter&$orderby&$top&$skip}",
-            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/mappetype",
+            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/mappetype/",
             "templated": true
         }
     ]
@@ -450,17 +451,17 @@ http://localhost:49708/api/arkivstruktur/Mappe/a043d07b-9641-44ad-85d8-056730bc8
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Mappe/515c45b5-e903-4320-a085-2a98813878ba",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/mappe",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/mappe/",
             "templated": false
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Mappe/515c45b5-e903-4320-a085-2a98813878ba/avslutt",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/avslutt-mappe",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/avslutt-mappe/",
             "templated": false
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Mappe/515c45b5-e903-4320-a085-2a98813878ba/utvid-til-saksmappe",
-            "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe",
+            "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe/",
             "templated": false
         },
 ```
@@ -506,12 +507,12 @@ hentes fra slik som mappetype og dokumentmedium.
     "_links": [
         {
             "href": "http://localhost:49708/api/kodelister/Dokumentmedium{?$filter&$orderby&$top&$skip}",
-            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/dokumentmedium",
+            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/dokumentmedium/",
             "templated": true
         },
         {
             "href": "http://localhost:49708/api/kodelister/Mapetype{?$filter&$orderby&$top&$skip}",
-            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/mappetype",
+            "rel": "http://rel.kxml.no/noark5/v4/api/administrasjon/mappetype/",
             "templated": true
         }
     ]
@@ -609,17 +610,17 @@ http://localhost:49708/api/arkivstruktur/Mappe/a043d07b-9641-44ad-85d8-056730bc8
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Mappe/515c45b5-e903-4320-a085-2a98813878ba",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/mappe",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/mappe/",
             "templated": false
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Mappe/515c45b5-e903-4320-a085-2a98813878ba/avslutt",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/avslutt-mappe",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/avslutt-mappe/",
             "templated": false
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Mappe/515c45b5-e903-4320-a085-2a98813878ba/utvid-til-saksmappe",
-            "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe",
+            "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe/",
             "templated": false
         },
 ```
@@ -648,7 +649,7 @@ Ved uthenting av en mappe vil du få følgende relasjon tilbake:
 
 ```Python
 {
-    "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe",
+    "rel": "http://rel.kxml.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe/",
     "href": "http://n5test.kxml.no/api/sakarkiv/Saksmappe/1/utvid-til-saksmappe",
     "templated": false
 }
@@ -891,7 +892,7 @@ Datoformat skal være angitt ihht http://www.w3.org/TR/NOTE-datetime
 
 Ved navigering til dokumentobjekt så kan selve filen også åpnes ved å
 følge referanseDokumentfil eller href til relasjonsnøkkel
-http://rel.kxml.no/noark5/v4/arkivstruktur/fil
+http://rel.kxml.no/noark5/v4/arkivstruktur/fil/.
 
 GET http://localhost:49708/api/arkivstruktur/Dokumentobjekt/a895c8ed-c15a-43f6-86de-86a626433785
 
@@ -916,12 +917,12 @@ GET http://localhost:49708/api/arkivstruktur/Dokumentobjekt/a895c8ed-c15a-43f6-8
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Dokumentobjekt/a895c8ed-c15a-43f6-86de-86a626433785",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/dokumentobjekt",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/dokumentobjekt/",
             "templated": false
         },
         {
             "href": "http://localhost:49708/api/arkivstruktur/Dokumentobjekt/a895c8ed-c15a-43f6-86de-86a626433785/referanseFil",
-            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/fil",
+            "rel": "http://rel.kxml.no/noark5/v4/api/arkivstruktur/fil/",
             "templated": false
         }
     ]
@@ -936,7 +937,7 @@ streames til klient
 **Overføre små filer**
 
 For å overføre en ny fil brukes POST til href til
-rel="http://rel.kxml.no/noark5/v4/api/arkivstruktur/fil" med headere for
+rel="http://rel.kxml.no/noark5/v4/api/arkivstruktur/fil/" med headere for
 content-type og content-length.
 
 ```
@@ -957,7 +958,7 @@ https://developers.google.com/drive/v3/web/resumable-upload .
 For å starte en opplastingssesjon:
 
 1.  Send en POST til href til
-    rel="http://rel.kxml.no/noark5/v4/api/arkivstruktur/fil"
+    rel="http://rel.kxml.no/noark5/v4/api/arkivstruktur/fil/"
 
     Headeren Content-Length settes til 0
     


### PR DESCRIPTION
Add trailing slash to all resource links without it, and mention the
need for a trailing slash where resource links are described.

This fixes issue #15.