### PR TITLE
Klargjør bruk av navn på SHA-256 og verdipresentasjon.

### DIFF
--- a/kapitler/02-normative_referanser.md
+++ b/kapitler/02-normative_referanser.md
@@ -14,3 +14,6 @@ konsortiumet [Object Management Group] (OMG) - http://www.omg.org/spec/UML/
 
 Webtjenester med REST/HATEOAS -
 https://tools.ietf.org/html/draft-kelly-json-hal-08
+
+Sjekksumalgoritmen SHA-256 er definiert i IETF RFC 4634 -
+https://tools.ietf.org/html/rfc4634

--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -658,7 +658,7 @@ Table: Restriksjoner
 | M705 sjekksum: Kan ikke endres. | |
 | M705 sjekksum: Sjekksummen skal være heksadesimal uten noen formatteringstegn. | |
 | M706 sjekksumAlgoritme: Kan ikke endres | |
-| M706 sjekksumAlgoritme: Algoritmen som skal brukes inntil videre er SHA256. | |
+| M706 sjekksumAlgoritme: Algoritmen som skal brukes inntil videre er SHA-256, med verdi presentert i hexadesimal form.  Obligatorisk verdi: «SHA-256» | |
 | M707 filstoerrelse: Kan ikke endres | |
 
 #### ElektroniskSignatur


### PR DESCRIPTION
API skal bruke samme format som brukes ved avlevering, dvs.
'SHA-256' og hexadesimal presentasjon.

Fixes #31