### PR TITLE
Klargjør at _links-listene skal være sortert

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -151,7 +151,8 @@ benyttes. De ressurser som støtter filter skal annonserer dette under
 **\_links** med **templated=true** og parametre som kan brukes til dette i
 **href**. Feltet «templated» er valgfritt og verdien skal antas å være «false»
 hvis det ikke finnes.  Typiske parametre er **$filter**, **$top**, **$skip**
-og **$orderby**. Alle lister med data bør støtte søk og filtrering.
+og **$orderby**. Alle lister med data bør støtte søk og filtrering.  Ressurslisten
+i _links er alfabetisk sortert på «rel»-feltet i henhold til ASCII-verdi.
 
 ```Python
 {


### PR DESCRIPTION
Dette sikrer stabilt resultat på tvers av implementasjoner.

Fixes #27