### PR TITLE
Corrected M707 field name typo (filstørrelse -> filstoerrelse)

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -635,7 +635,7 @@ Table: Attributter
 | sjekksum             | Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir integritetssikring til dokumentets innhold . Kilde: Påføres automatisk i forbindelse med eksport for avlevering. Kommentarer: (ingen). M705 | \[0..1\] | | string | 
 | mimeType             | veMimeType i n4 | \[0..1\]    |           | string | 
 | sjekksumAlgoritme    | Definisjon: Algoritmen som er brukt for å beregne sjekksummen . Kilde: Registreres automatisk i forbindelse med eksport for avlevering. Kommentarer: (ingen). M706 | \[0..1\] | | string | 
-| filstørrelse         | Definisjon: Størrelsen på fila i antall bytes oppgitt med desimaltall . Kilde: Registreres automatisk i forbindelse med eksport for avlevering. Kommentarer: (ingen). M707 | \[0..1\] | string | 
+| filstoerrelse         | Definisjon: Størrelsen på fila i antall bytes oppgitt med desimaltall . Kilde: Registreres automatisk i forbindelse med eksport for avlevering. Kommentarer: (ingen). M707 | \[0..1\] | string |
 | elektroniskSignatur  |              | \[0..1\]       |           | ElektroniskSignatur |
 
 Table: Restriksjoner


### PR DESCRIPTION
This fixes one typo in the text.  There are still typos in some of the
UML diagrams.

Related to issue #21