### PR TITLE
Use consistent stereotype name "codelist" everywhere.  Rename 4.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -1717,7 +1717,7 @@ Table: Attributter
 
 #### ElektroniskSignaturSikkerhetsnivå
 
-*Type:* ***Class «codeList»***
+*Type:* ***Class «codelist»***
 
 *Arver:* 
 
@@ -1777,7 +1777,7 @@ Table: Attributter
 
 #### FlytStatus
 
-*Type:* ***Class «codeList»***
+*Type:* ***Class «codelist»***
 
 *Arver:* 
 
@@ -2080,7 +2080,7 @@ Table: Attributter
 
 #### MøtedeltakerFunksjon
 
-*Type:* ***Class «codeList»***
+*Type:* ***Class «codelist»***
 
 *Arver:* 
 
@@ -2334,7 +2334,7 @@ Table: Attributter
 
 #### SkjermingMetadata
 
-*Type:* ***Class «codeList»***
+*Type:* ***Class «codelist»***
 
 *Arver:* 
 


### PR DESCRIPTION
4 of 35 class type entries used "codeList" instead of "codelist" as
their class stereotype indicator. Renamed the ones with camel case
to the form used by the majority, which also is the form used in the
UML diagrams