### PR TITLE
Redrew all UML diagrams using PlantUML for easier maintenance.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
-IMG_EMF := $(wildcard media/*.emf)
-IMG_PNG := $(IMG_EMF:.emf=.png)
+IMG_PUML := $(wildcard media/*.puml)
+IMG_PNG := $(IMG_PUML:.puml=.png)
 
 PANDOC_TYPE = markdown_github+table_captions+auto_identifiers+implicit_figures
 
@@ -10,9 +10,8 @@ pdf: spesifikasjon.pdf
 
 images: $(IMG_PNG)
 
-.emf.png:
-	inkscape --export-dpi=72 --export-png=$@ $^
-	#cd $(dirname $@); libreoffice --headless --convert-to png $(abspath $^)
+.puml.png:
+	plantuml -p < $^ > $@
 
 # Draft Docbook based PDF building.  Remove colwidth to let the
 # docbook processors calculate columns widths.  Can pandoc be told to
@@ -45,7 +44,7 @@ spesifikasjon.html: docbook images
 	pandoc -f $(PANDOC_TYPE) -t latex $^ -o $@
 
 .PHONY: docbook
-.SUFFIXES: .md .pdf .docx .emf .png
+.SUFFIXES: .md .pdf .docx .puml .png
 
 clean:
 	$(RM) $(IMG_PNG)

--- a/media/uml-administrasjon.puml
+++ b/media/uml-administrasjon.puml
@@ -1,0 +1,27 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-bruker.iuml
+!include media/uml-class-administrativenhet.iuml
+!include media/uml-class-tilgang.iuml
+!include media/uml-codelist-tilgangsrestriksjon.iuml
+!include media/uml-codelist-tilgangskategori.iuml
+
+Admin.Bruker "+bruker 0..*" <--> "+enhet 0..*" Admin.AdministrativEnhet
+
+note "Aktuelle roller:\nArkivansvarlig\nArkivpersonale\nLeder\nSaksbehandler" as Roller
+
+note "Roller kan komme fra\nautentiseringsløsningen\n(som Claims)" as RolleNote
+
+Admin.Bruker .. RolleNote
+RolleNote .. Admin.Tilgang
+
+Roller .. RolleNote
+
+note "Saksbehandlerrolle X i fagsystem A = rolle\nfår lese tilgang til arkivdel med systemid=2\nkan lese, opprette og endre klasser\nKan lese, opprette og endre mapper\nKan IKKE lese mapper Personalsaker\nKan lese, opprette og endre registreringer\nKan lese, opprette og endre dokumentobjekt\nKan IKKE lese graderte dokumentobjekt" as Saksbehandlerrolle
+
+Kodelister.Tilgangsrestriksjon --[hidden]-> Saksbehandlerrolle
+Saksbehandlerrolle -[hidden]> Kodelister.Tilgangskategori
+Kodelister.Tilgangskategori -[hidden]> Admin.Tilgang
+
+@enduml

--- a/media/uml-arkivenheter-som-har-noe-med-bevaring-og-kassasjon-aa-gjoere.puml
+++ b/media/uml-arkivenheter-som-har-noe-med-bevaring-og-kassasjon-aa-gjoere.puml
@@ -1,0 +1,27 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-arkivdel.iuml
+!include media/uml-datatype-skjerming.iuml
+!include media/uml-codelist-tilgangsrestriksjon.iuml
+!include media/uml-datatype-kassasjon.iuml
+!include media/uml-codelist-skjermingdokument.iuml
+!include media/uml-class-klasse.iuml
+!include media/uml-datatype-utfoertkassasjon.iuml
+!include media/uml-codelist-kassasjonsvedtak.iuml
+!include media/uml-datatype-sletting.iuml
+!include media/uml-codelist-slettingstype.iuml
+!include media/uml-class-mappe.iuml
+!include media/uml-datatype-gradering.iuml
+!include media/uml-codelist-skjermingmetadata.iuml
+!include media/uml-class-registrering.iuml
+!include media/uml-codelist-graderingskode.iuml
+!include media/uml-class-dokumentbeskrivelse.iuml
+
+Arkivstruktur.Gradering <-[hidden]-- Kodelister.Graderingskode
+Arkivstruktur.Sletting <-[hidden]-- Kodelister.Slettingstype
+Arkivstruktur.Skjerming <-[hidden]-- Kodelister.SkjermingDokument
+Arkivstruktur.Skjerming <-[hidden]-- Kodelister.SkjermingMetadata
+Arkivstruktur.Skjerming <-[hidden]-- Kodelister.Tilgangsrestriksjon
+Arkivstruktur.Kassasjon <-[hidden]-- Kodelister.Kassasjonsvedtak
+@enduml

--- a/media/uml-arkivstruktur-arkiv-og-arkivdel.puml
+++ b/media/uml-arkivstruktur-arkiv-og-arkivdel.puml
@@ -1,0 +1,97 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class Arkivstruktur.Arkivskaper <Arkivenhet> {
+  +arkivskaperID : string
+  +arkivskaperNavn : string
+  +beskrivelse : string [0..1]
+
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+class Arkivstruktur.Arkiv <Arkivenhet> {
+  +tittel : string
+  +beskrivelse ; string [0..1]
+  +arkivstatus : Arkivstatus [0..1]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+class Arkivstruktur.Arkivdel <Arkivenhet> {
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +arkivdelstatus : Arkivdelstatus
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +arkivperiodeStartDato : date [0..1]
+  +arkivperiodeSluttDato : date [0..1]
+  +referanseForløper : SystemID [0..1]
+  +referanseArvtaker : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +utførtKassasjon : UtførtKassasjon [0..1]
+  +sletting : Sletting [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+!include media/uml-codelist-arkivstatus.iuml
+!include media/uml-codelist-dokumentmedium.iuml
+!include media/uml-codelist-arkivdelstatus.iuml
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Klassifikasjonssystem <Arkivenhet>
+!include media/uml-datatype-kassasjon.iuml
+!include media/uml-datatype-utfoertkassasjon.iuml
+!include media/uml-datatype-sletting.iuml
+!include media/uml-datatype-skjerming.iuml
+!include media/uml-datatype-gradering.iuml
+!include media/uml-codelist-kassasjonsvedtak.iuml
+!include media/uml-codelist-slettingstype.iuml
+!include media/uml-codelist-skjermingdokument.iuml
+!include media/uml-codelist-graderingskode.iuml
+
+Arkivstruktur.Arkivskaper "+arkivskaper 1..*" <-o "+arkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv o--> "+underarkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" <-o "+arkivdel 1..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+sekundærklassifikasjonssystem 0..*" <-o Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o-> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+
+Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.Sletting
+Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.Kassasjon
+Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.UtførtKassasjon
+Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.Skjerming
+Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.Gradering
+Arkivstruktur.Sletting <-[hidden]- Kodelister.Slettingstype
+Arkivstruktur.Gradering <-[hidden] Kodelister.Graderingskode
+Arkivstruktur.Kassasjon <-[hidden]- Kodelister.Kassasjonsvedtak
+Arkivstruktur.Skjerming <-[hidden]- Kodelister.SkjermingDokument
+@enduml

--- a/media/uml-arkivstruktur-arkivenhet-som-basis-klasse.puml
+++ b/media/uml-arkivstruktur-arkivenhet-som-basis-klasse.puml
@@ -1,0 +1,51 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-arkivenhet.iuml
+class Arkivstruktur.Arkivskaper <Arkivenhet>
+class Arkivstruktur.Arkiv <Arkivenhet>
+class Arkivstruktur.Arkivdel <Arkivenhet>
+class Arkivstruktur.Klassifikasjonssystem <Arkivenhet>
+class Arkivstruktur.Klasse <Arkivenhet>
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Basisregistrering <Registrering>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+class Sakarkiv.Journalpost <Basisregistrering>
+class Sakarkiv.Saksmappe <Mappe>
+
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Arkivskaper
+Arkivstruktur.Arkivenhet <|--  Arkivstruktur.Arkiv
+Arkivstruktur.Arkivskaper --o "+arkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+underarkiv 0..*" --o Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+arkiv 1" --o "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Klassifikasjonssystem
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" --o "+arkivdel 1..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "\n+sekundærklassifikasjonssystem 0..*" --o Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o-- "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Klasse
+Arkivstruktur.Klasse --o "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Mappe
+Arkivstruktur.Arkivdel "\n+arkivdel 0..1" o-- "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+klasse 0..1" o-- "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o-- "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Registrering
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o-- "+registrering 0..*" .Arkivstruktur.Registrering
+Arkivstruktur.Mappe "+mappe 0..1" o-- "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Klasse "+klasse 0..1" o-- "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Registrering "+registrering 1..*" o-- "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+
+Arkivstruktur.Registrering <|-- Arkivstruktur.Basisregistrering
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+
+!include media/uml-class-endringslogg.iuml
+!include media/uml-class-hendelseslogg.iuml
+!include media/uml-codelist-hendelsetype.iuml
+
+Arkivstruktur.Arkivenhet "0..1" o-- "+logg 0..*" Arkivstruktur.Hendelseslogg
+LoggingOgSporing.Endringslogg <|-- Arkivstruktur.Hendelseslogg
+Arkivstruktur.Hendelseslogg -[hidden]> Kodelister.Hendelsetype
+@enduml

--- a/media/uml-arkivstruktur-attributter.puml
+++ b/media/uml-arkivstruktur-attributter.puml
@@ -1,0 +1,40 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-arkivskaper.iuml
+!include media/uml-class-arkiv.iuml
+!include media/uml-class-klassifikasjonssystem.iuml
+!include media/uml-class-klasse.iuml
+!include media/uml-class-arkivdel.iuml
+!include media/uml-class-mappe.iuml
+!include media/uml-class-merknad.iuml
+!include media/uml-class-registrering.iuml
+!include media/uml-class-basisregistrering.iuml
+!include media/uml-class-dokumentbeskrivelse.iuml
+!include media/uml-class-dokumentobjekt.iuml
+!include media/uml-class-konvertering.iuml
+!include media/uml-datatype-elektronisksignatur.iuml
+
+Arkivstruktur.Arkiv "+arkiv 0..*" o--> "+arkivskaper 1..*" Arkivstruktur.Arkivskaper
+Arkivstruktur.Arkiv o--> "+underarkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" <--o "+arkivdel 1..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+sekundærklassifikasjonssystem 0..*" <--o Arkivstruktur.Arkivdel
+
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o--> "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Klasse --> "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Mappe --> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Merknad "+merknad 0..*" <-* Arkivstruktur.Mappe
+Arkivstruktur.Merknad "+merknad 0..*" <--* Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Basisregistrering -|> Arkivstruktur.Registrering
+Arkivstruktur.Merknad "+merknad 0..*" <--* Arkivstruktur.Basisregistrering
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+Arkivstruktur.Dokumentobjekt *-> "+konvertering 0..*" Arkivstruktur.Konvertering
+Arkivstruktur.ElektroniskSignatur -[hidden]-> Arkivstruktur.Dokumentobjekt
+@enduml

--- a/media/uml-arkivstruktur-dokumentbeskrivelse-og-dokumentobjekt.puml
+++ b/media/uml-arkivstruktur-dokumentbeskrivelse-og-dokumentobjekt.puml
@@ -1,0 +1,44 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class Arkivstruktur.Registrering <Arkivenhet>
+!include media/uml-class-dokumentobjekt.iuml
+!include media/uml-class-merknad.iuml
+!include media/uml-class-konvertering.iuml
+
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet> {
+  +dokumenttype : Dokumenttype
+  +dokumentstatus : Dokumentstatus
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +forfatter : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..1]
+  +tilknyttetRegistreringSom : TilknyttetRegistreringSom
+  +dokumentnummer : integer
+  +tilknyttetDato : date
+  +tilknyttetAv : string [0..1]
+  +referanseTilknyttetAv : systemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +utførtKassasjon : UtførtKassasjon [0..1]
+  +sletting : Sletting [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +elektroniskSignatur : ElektroniskSignatur [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOppdatertav : SystemID [0..1]
+}
+
+
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Dokumentbeskrivelse *-> "+merknad 0..*" Arkivstruktur.Merknad
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+Arkivstruktur.Dokumentobjekt *-> "+konvertering 0..*" Arkivstruktur.Konvertering
+@enduml

--- a/media/uml-arkivstruktur-forenklet-modell.puml
+++ b/media/uml-arkivstruktur-forenklet-modell.puml
@@ -1,0 +1,12 @@
+@startuml
+skinparam classAttributeIconSize 0
+class Arkivstruktur.Arkiv <Arkivenhet>
+class Arkivstruktur.Arkivdel <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+class Arkivstruktur.Dokumentobjekt
+Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering  0..*" Arkivstruktur.Registrering
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+@enduml

--- a/media/uml-arkivstruktur-forklart-som-hovedmodell.puml
+++ b/media/uml-arkivstruktur-forklart-som-hovedmodell.puml
@@ -1,0 +1,26 @@
+@startuml
+skinparam classAttributeIconSize 0
+class Arkivstruktur.Arkiv <Arkivenhet>
+class Arkivstruktur.Arkivdel <Arkivenhet>
+class Arkivstruktur.Klassifikasjonssystem <Arkivenhet>
+class Arkivstruktur.Klasse <Arkivenhet>
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+class Arkivstruktur.Dokumentobjekt
+
+Arkivstruktur.Arkiv o--> "+underarkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*\n" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem  0..1" <-o "+arkivdel 1..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+sekundærklassifikasjonssystem  0..1" <-o Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o--> "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse o-> "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering  0..*\n" Arkivstruktur.Registrering
+Arkivstruktur.Arkivdel "\n+arkivdel 0..1" o--> "+mappe  0..*" Arkivstruktur.Mappe
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+@enduml

--- a/media/uml-arkivstruktur-klassifikasjon.puml
+++ b/media/uml-arkivstruktur-klassifikasjon.puml
@@ -1,0 +1,51 @@
+@startuml
+skinparam classAttributeIconSize 0
+class Arkivstruktur.Arkivdel <Arkivenhet>
+class Arkivstruktur.Klassifikasjonssystem <Arkivenhet> {
+  +klassifikasjonstype : Klassifikasjonstype [0..1]
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+class Arkivstruktur.Klasse <Arkivenhet> {
+  +klasseID : string
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +skjerming : Skjerming [0..1]
+  +kassasjon : Kassasjon [0..1]
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+class Arkivstruktur.Mappe <Arkivenhet>
+class Sakarkiv.Saksmappe <Mappe>
+
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" <-o "+arkivdel 1..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+sekundærklassifikasjonssystem 0..1" <-o Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" <--o "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse o--> "+underklasse" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*\n" Arkivstruktur.Mappe
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
+Arkivstruktur.Klasse "+sekundærklassifikasjon 0..*" <--o Sakarkiv.Saksmappe
+@enduml

--- a/media/uml-arkivstruktur-kryssreferanse.puml
+++ b/media/uml-arkivstruktur-kryssreferanse.puml
@@ -1,0 +1,14 @@
+@startuml
+skinparam classAttributeIconSize 0
+!include media/uml-class-basisregistrering.iuml
+!include media/uml-class-klasse.iuml
+!include media/uml-class-mappe.iuml
+!include media/uml-class-kryssreferanse.iuml
+
+Arkivstruktur.Basisregistrering "+registrering 0..1" <--> "+kryssreferanse 0..*" Arkivstruktur.Kryssreferanse
+Arkivstruktur.Kryssreferanse "+kryssreferanse 0..*" <--> "+mappe 0..1" Arkivstruktur.Mappe
+Arkivstruktur.Kryssreferanse "+kryssreferanse 0..*" <--> "+klasse 0..1" Arkivstruktur.Klasse
+Arkivstruktur.Klasse o-> "+underklasse o..*" Arkivstruktur.Klasse
+Arkivstruktur.Mappe o-> "+undermappe o..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+@enduml

--- a/media/uml-arkivstruktur-mappe-til-saksmappe.puml
+++ b/media/uml-arkivstruktur-mappe-til-saksmappe.puml
@@ -1,0 +1,31 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class Arkivstruktur.Klasse <Arkivenhet>
+class Arkivstruktur.Arkivdel <Arkivenhet>
+!include media/uml-class-saksmappe.iuml
+!include media/uml-class-mappe-all.iuml
+class Sakarkiv.Presedens
+class Arkivstruktur.Registrering <Arkivenhet>
+class MøteOgUtvalgsbehandling.Møtemappe {
+  +møtenummer : string [0..1]
+  +utvalg : string
+  +møtedato : datetime
+  +møtested : string [0..1]
+  +referanseForrigeMøte : SystemID [0..1]
+  +referanseNesteMøte : SystemID [0..1]
+}
+
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Klasse --o "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+sekundærklassifikasjon 0..*" <--o Sakarkiv.Saksmappe
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
+Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
+Arkivstruktur.Mappe <|-- MøteOgUtvalgsbehandling.Møtemappe
+
+@enduml

--- a/media/uml-arkivstruktur-mappe.puml
+++ b/media/uml-arkivstruktur-mappe.puml
@@ -1,0 +1,20 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class Arkivstruktur.Klasse <Arkivenhet>
+class Arkivstruktur.Arkivdel <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+!include media/uml-class-mappe-all.iuml
+!include media/uml-class-merknad.iuml
+class Arkivstruktur.NasjonalIdentifikatorer.NasjonalIdentifikator {
+  +systemID : SystemID [0..1]
+  +beskrivelse : string [0..1]
+}
+
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Mappe *-> "+merknad 0..*" Arkivstruktur.Merknad
+Arkivstruktur.NasjonalIdentifikatorer.NasjonalIdentifikator "+nasjonalidentifikator 0..*" <-* Arkivstruktur.Mappe
+@enduml

--- a/media/uml-arkivstruktur-merknad.puml
+++ b/media/uml-arkivstruktur-merknad.puml
@@ -1,0 +1,11 @@
+@startuml
+skinparam classAttributeIconSize 0
+!include media/uml-class-merknad.iuml
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Basisregistrering <Registrering>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+Arkivstruktur.Mappe *-- "+merknad 0..*" Arkivstruktur.Merknad
+Arkivstruktur.Mappe "+undermappe 0..*" --o Arkivstruktur.Mappe
+Arkivstruktur.Basisregistrering *-- "+merknad 0..*" Arkivstruktur.Merknad
+Arkivstruktur.Dokumentbeskrivelse *-- "+merknad 0..*" Arkivstruktur.Merknad
+@enduml

--- a/media/uml-arkivstruktur-omfattende-forklart.puml
+++ b/media/uml-arkivstruktur-omfattende-forklart.puml
@@ -1,0 +1,81 @@
+@startuml
+skinparam classAttributeIconSize 0
+!include media/uml-class-arkivskaper.iuml
+!include media/uml-class-arkiv.iuml
+!include media/uml-class-arkivdel.iuml
+!include media/uml-class-klassifikasjonssystem.iuml
+!include media/uml-class-klasse.iuml
+!include media/uml-class-kryssreferanse.iuml
+!include media/uml-class-mappe.iuml
+!include media/uml-class-merknad.iuml
+!include media/uml-class-saksmappe.iuml
+!include media/uml-class-sakspart.iuml
+!include media/uml-class-journalpost.iuml
+!include media/uml-class-korrespondansepart.iuml
+class MøteOgUtvalgsbehandling.Møtemappe {
+  +møtenummer : string [0..1]
+  +utvalg : string
+  +møtedato : datetime
+  +møtested : string [0..1]
+  +referanseForrigeMøte : SystemID [0..1]
+  +referanseNesteMøte : SystemID [0..1]
+}
+!include media/uml-class-registrering.iuml
+!include media/uml-class-dokumentbeskrivelse.iuml
+!include media/uml-class-basisregistrering.iuml
+!include media/uml-class-dokumentobjekt.iuml
+class MøteOgUtvalgsbehandling.Møteregistrering {
+  +møteregistreringstype : Møteregistreringstype
+  +møtesakstype : Møtesakstype
+  +møteregistreringsstatus : Møteregistreringsstatus [0..1]
+  +administrativEnhet : string
+  +referanseAdministrativEnhet : SystemID [0..1]
+  +saksbehandler : string
+  +referanseSaksbehandler : SystemID [0..1]
+  +referanseTilMøteregistrering : SystemID [0..1]
+  +referanseFraMøteregistrering : SystemID [0..1]
+}
+!include media/uml-class-konvertering.iuml
+!include media/uml-datatype-elektronisksignatur.iuml
+class "Noark5 - Sektorspesifikke data.Fil" {
+}
+class "Noark5 - Sektorspesifikke data.FilInnhold" {
+  +base64 : base64Binary
+}
+class "Noark5 - Sektorspesifikke data.FilReferanse" {
+  +uri : anyURI
+  +kvitteringsUri : anyURI [0..1]
+}
+
+Arkivstruktur.Arkivskaper "+arkivskaper 1..*" <-o "+arkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv o--> "+underarkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..*" <-o "+arkivdel 1..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+sekundærklassifikasjonssystem 0..*" <-o Arkivstruktur.Arkivdel
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o--> "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse o-> "+underklasse 0..1" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" <-> "+kryssreferanse 0..*" Arkivstruktur.Kryssreferanse
+Arkivstruktur.Mappe "+mappe 0..1" <-> "+kryssreferanse 0..*" Arkivstruktur.Kryssreferanse
+Arkivstruktur.Kryssreferanse "+kryssreferanse 0..*" <--> "+registrering 0..1" Arkivstruktur.Basisregistrering
+Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Klasse "+sekundærklassifikasjon 0..*" <--o Sakarkiv.Saksmappe
+Arkivstruktur.Klasse "+klasse 0..*" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
+Arkivstruktur.Mappe <|- MøteOgUtvalgsbehandling.Møtemappe
+Sakarkiv.Saksmappe *--> "+sakspart 0..*" Sakarkiv.Sakspart
+Arkivstruktur.Mappe *-> "+merknad 0..*" Arkivstruktur.Merknad
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Merknad "+merknad 0..*" <--* Arkivstruktur.Basisregistrering
+Arkivstruktur.Registrering <|- Arkivstruktur.Basisregistrering
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Merknad "+merknad 0..*" <--* Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+Arkivstruktur.Basisregistrering <|-- MøteOgUtvalgsbehandling.Møteregistrering
+Sakarkiv.Journalpost *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Arkivstruktur.Dokumentobjekt *--> "+konvertering 0..*" Arkivstruktur.Konvertering
+
+"Noark5 - Sektorspesifikke data.Fil" <|-- "Noark5 - Sektorspesifikke data.FilInnhold"
+"Noark5 - Sektorspesifikke data.Fil" <|-- "Noark5 - Sektorspesifikke data.FilReferanse"
+@enduml

--- a/media/uml-arkivstruktur-registrering-til-basisregistrering-til-journalpost.puml
+++ b/media/uml-arkivstruktur-registrering-til-basisregistrering-til-journalpost.puml
@@ -1,0 +1,29 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class Arkivstruktur.Registrering <Arkivenhet> {
+  +arkivertDato : datetime [0..1]
+  +arkivertAv : string [0..1]
+  +referanseArkivertAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseArkivdel : SystemID [0..1]
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+
+!include media/uml-class-basisregistrering.iuml
+
+class Sakarkiv.Journalpost <Basisregistrering>
+
+Arkivstruktur.Registrering <|-- Arkivstruktur.Basisregistrering
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+
+@enduml

--- a/media/uml-arkivstruktur-skjerming.puml
+++ b/media/uml-arkivstruktur-skjerming.puml
@@ -1,0 +1,31 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-klasse.iuml
+!include media/uml-class-mappe.iuml
+!include media/uml-class-dokumentbeskrivelse.iuml
+!include media/uml-class-registrering.iuml
+!include media/uml-class-merknad.iuml
+!include media/uml-datatype-skjerming.iuml
+!include media/uml-codelist-skjermingmetadata.iuml
+!include media/uml-codelist-skjermingdokument.iuml
+!include media/uml-codelist-tilgangsrestriksjon.iuml
+!include media/uml-class-tilgang.iuml
+
+Arkivstruktur.Klasse o--> "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" o-> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o-> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Registrering "+registrering" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Mappe *-> "+merknad 0..*" Arkivstruktur.Merknad
+Arkivstruktur.Dokumentbeskrivelse *-> "+merknad 0..*" Arkivstruktur.Merknad
+
+Arkivstruktur.Registrering <-[hidden]- Arkivstruktur.Skjerming
+Arkivstruktur.Dokumentbeskrivelse <-[hidden]- Arkivstruktur.Skjerming
+Arkivstruktur.Dokumentbeskrivelse <-[hidden]- Kodelister.Tilgangsrestriksjon
+Admin.Tilgang <-[hidden]- Kodelister.Tilgangsrestriksjon
+Arkivstruktur.Skjerming <-[hidden]- Kodelister.SkjermingMetadata
+Arkivstruktur.Skjerming <-[hidden]- Kodelister.SkjermingDokument
+
+@enduml

--- a/media/uml-assosiasjoner-brukt-med-klasser.puml
+++ b/media/uml-assosiasjoner-brukt-med-klasser.puml
@@ -1,0 +1,8 @@
+@startuml
+skinparam classAttributeIconSize 0
+'FIXME dropped caption "class Fig03_Assosiasjon"
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe 
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+@enduml

--- a/media/uml-bruken-av-nasjonalidentifikator.puml
+++ b/media/uml-bruken-av-nasjonalidentifikator.puml
@@ -1,0 +1,78 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class NasjonaleIdentifikatorer.Nasjonalidentifikator {
+  +systemID : SystemID [0..1]
+  +beskrivelse : string [0..1]
+}
+
+
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class NasjonaleIdentifikatorer.Enhetsidentifikator {
+  +organisasjonsnummer : string
+}
+class NasjonaleIdentifikatorer.Personidentifikator {
+  +fødselsnummer : string [0..1]
+  +dNummer : string [0..1]
+}
+class NasjonaleIdentifikatorer.Posisjon {
+  +plassering : Punkt
+}
+class NasjonaleIdentifikatorer.Bygning {
+  +byggidentifikator : ByggIdent
+}
+class NasjonaleIdentifikatorer.Matrikkel {
+  +matrikkelnummer : Matrikkelnummer
+}
+class NasjonaleIdentifikatorer.Plan {
+  +planidentifikator : NasjonalArealplanId
+}
+
+package GeoIntegration {
+
+  package Geometri {
+
+    class Punkt <Geometri> <<dataType>> {
+      +posisjon : Koordinat
+      -- Geometri --
+      +koordinatsystem : KoordinatsystemKode
+    }
+  }
+
+  package Felles {
+    class ByggIdent <<dataType>> {
+      +bygningsNummer : Integer
+      +endringsløpenummer : Integer [0..1]
+    }
+
+    class NasjonalArealplanId {
+      +nummer : Administrativenhetsnummer
+      +planidentifikasjon : string
+    }
+
+    class "Matrikkelnummer\n{root,leaf}" as Matrikkelnummer <<dataType>> {
+      +kommunenummer : String
+      +gårdsnummer : Integer
+      +bruksnummer : Integer
+      +festenummer : Integer [0..1]
+     +seksjonsnummer : Integer [0..1]
+    }
+  }
+}
+Arkivstruktur.Mappe --> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Registrering "+registrering 0..*" <-o "+mappe 0..1" Arkivstruktur.Mappe
+Arkivstruktur.Mappe *--> "+nasjonalidentifikator 0..*\n\n" NasjonaleIdentifikatorer.Nasjonalidentifikator
+Arkivstruktur.Registrering *--> "+nasjonalidentifikator 0..*\n" NasjonaleIdentifikatorer.Nasjonalidentifikator
+NasjonaleIdentifikatorer.Posisjon -|> NasjonaleIdentifikatorer.Nasjonalidentifikator
+NasjonaleIdentifikatorer.Nasjonalidentifikator <|- NasjonaleIdentifikatorer.Personidentifikator
+NasjonaleIdentifikatorer.Nasjonalidentifikator <|-- NasjonaleIdentifikatorer.Enhetsidentifikator
+NasjonaleIdentifikatorer.Nasjonalidentifikator <|-- NasjonaleIdentifikatorer.Bygning
+NasjonaleIdentifikatorer.Nasjonalidentifikator <|-- NasjonaleIdentifikatorer.Matrikkel
+NasjonaleIdentifikatorer.Nasjonalidentifikator <|-- NasjonaleIdentifikatorer.Plan
+
+NasjonaleIdentifikatorer.Plan <-[hidden]-- NasjonalArealplanId
+NasjonaleIdentifikatorer.Posisjon <-[hidden]-- Punkt
+NasjonaleIdentifikatorer.Bygning <-[hidden]-- ByggIdent
+NasjonaleIdentifikatorer.Matrikkel <-[hidden]-- Matrikkelnummer
+@enduml

--- a/media/uml-class-administrativenhet.iuml
+++ b/media/uml-class-administrativenhet.iuml
@@ -1,0 +1,13 @@
+@startuml
+class Admin.AdministrativEnhet {
+  +systemID : SystemID [0..1]
+  +administrativEnhetNavn : string
+  +kortnavn : string [0..1]
+  +opprettetDato : datetime
+  +opprettetAv : string [0..1]
+  +avsluttetDato : datetime [0..1]
+  +administrativEnhetsstatus : string
+  +referanseOverordnetEnhet : SystemID [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+}
+@enduml

--- a/media/uml-class-arkiv.iuml
+++ b/media/uml-class-arkiv.iuml
@@ -1,0 +1,12 @@
+@startuml
+class Arkivstruktur.Arkiv <Arkivenhet> {
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +arkivstatus : Arkivstatus [0..1]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-arkivdel.iuml
+++ b/media/uml-class-arkivdel.iuml
@@ -1,0 +1,21 @@
+@startuml
+class Arkivstruktur.Arkivdel <Arkivenhet> {
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +arkivdelstatus : Arkivdelstatus
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +arkivperiodeStartDato : date [0..1]
+  +arkivperiodeSluttDato : date [0..1]
+  +referanseForløper : SystemID [0..1]
+  +referanseArvtaker : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +utførtKassasjon : UtførtKassasjon [0..1]
+  +sletting : Sletting [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+}
+@enduml

--- a/media/uml-class-arkivenhet.iuml
+++ b/media/uml-class-arkivenhet.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Arkivstruktur.Arkivenhet {
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-arkivskaper.iuml
+++ b/media/uml-class-arkivskaper.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Arkivstruktur.Arkivskaper <Arkivenhet> {
+  +arkivskaperID : string
+  +arkivskaperNavn : string
+  +beskrivelse : string [0..1]
+}
+@enduml

--- a/media/uml-class-avskrivning.iuml
+++ b/media/uml-class-avskrivning.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Sakarkiv.Avskrivning {
+  +systemID : SystemID [0..1]
+  +avskrivningsdato : date
+  +avskrevetAv : string
+  +referanseAvskrevetAv : SystemID [0..1]
+  +avskrivningsmåte : Avskrivningsmåte
+  +referanseAvskrivesAvJournalpost : SystemID [0..1]
+  +referanseAvskrivesAvKorrespondansepart : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-basisregistrering.iuml
+++ b/media/uml-class-basisregistrering.iuml
@@ -1,0 +1,13 @@
+@startuml
+class Arkivstruktur.Basisregistrering <Registrering> {
+  +registreringsID : string [0..1]
+  +tittel : string
+  +offentligTittel : string [0..1]
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +forfatter : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+}
+@enduml

--- a/media/uml-class-bruker.iuml
+++ b/media/uml-class-bruker.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Admin.Bruker {
+  +brukerNavn : string [0..1]
+  +opprettetDato : datetime
+  +opprettetAv : string [0..1]
+  +avsluttetDato : datetime [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+  +kortnavn : string [0..1]
+}
+@enduml

--- a/media/uml-class-dokumentbeskrivelse.iuml
+++ b/media/uml-class-dokumentbeskrivelse.iuml
@@ -1,0 +1,23 @@
+@startuml
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet> {
+  +dokumenttype : Dokumenttype
+  +dokumentstatus : Dokumentstatus
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +forfatter : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..1]
+  +tilknyttetRegistreringSom : TilknyttetRegistreringSom
+  +dokumentnummer : integer
+  +tilknyttetDato : date
+  +tilknyttetAv : string [0..1]
+  +referanseTilknyttetAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +utførtKassasjon : UtførtKassasjon [0..1]
+  +sletting : Sletting [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +elektroniskSignatur : ElektroniskSignatur [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+}
+@enduml

--- a/media/uml-class-dokumentflyt.iuml
+++ b/media/uml-class-dokumentflyt.iuml
@@ -1,0 +1,13 @@
+@startuml
+class Sakarkiv.Dokumentflyt {
+  +systemID : SystemID [0..1]
+  +flytTil : string
+  +referanseFlytTil : SystemID [0..1]
+  +flytFra : string
+  +referanseFlytFra : SystemID [0..1]
+  +flytMottattDato : datetime
+  +flytSendtDato : datetime
+  +flytStatus : FlytStatus
+  +flytMerknad : string [0..1]
+}
+@enduml

--- a/media/uml-class-dokumentobjekt.iuml
+++ b/media/uml-class-dokumentobjekt.iuml
@@ -1,0 +1,18 @@
+@startuml
+class Arkivstruktur.Dokumentobjekt {
+  +systemID : SystemID [0..1]
+  +versjonsnummer : integer
+  +variantformat : Variantformat
+  +format : Format [0..1]
+  +formatDetaljer : string [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +referanseDokumentfil : string [0..1]
+  +filnavn : string [0..1]
+  +sjekksum : string [0..1]
+  +mimeType : string [0..1]
+  +sjekksumalgoritme : string [0..1]
+  +filstørrelse : string [0..1]
+  +elektroniskSignatur : ElektroniskSignatur [0..1]
+}
+@enduml

--- a/media/uml-class-endringslogg.iuml
+++ b/media/uml-class-endringslogg.iuml
@@ -1,0 +1,12 @@
+@startuml
+class LoggingOgSporing.Endringslogg {
+  +systemID : SystemID [0..1]
+  +referanseArkivenhet : SystemID [0..1]
+  +referanseMetadata : string [0..1]
+  +endretDato : datetime
+  +endretAv : string
+  +referanseEndretAv : SystemID
+  +tidligereVerdi : string [0..1]
+  +nyVerdi : string [0..1]
+}
+@enduml

--- a/media/uml-class-hendelseslogg.iuml
+++ b/media/uml-class-hendelseslogg.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Arkivstruktur.Hendelseslogg <Endringslogg> {
+  +hendelsetype : Hendelsetype
+  +beskrivelse : string [0..1]
+  +hendelseDato : datetime
+}
+@enduml

--- a/media/uml-class-journalpost-all.iuml
+++ b/media/uml-class-journalpost-all.iuml
@@ -1,0 +1,50 @@
+@startuml
+class Sakarkiv.Journalpost <Basisregistrering> {
+  +journalår : integer [0..1]
+  +journalsekvensnummer : integer [0..1]
+  +journalpostnummer : integer [0..1]
+  +journalposttype : Journalposttype
+  +journalstatus : Journalstatus
+  +journaldato : date
+  +dokumentetsDato : date [0..1]
+  +mottattDato : date [0..1]
+  +sendtDato : date [0..1]
+  +forfallsdato : dato [0..1]
+  +offentlighetsvurdertDato : date [0..1]
+  +antallVedlegg : integer [0..1]
+  +utlantDato : date [0..1]
+  +utlåntTil : string [0..1]
+  +referanseUtlåntTil : SystemID [0..1]
+  +journalenhet : string [0..1]
+  +elektroniskSignatur : ElektroniskSignatur [0..1]
+
+  -- Basisregistrering --
+  +registreringID : string [0..1]
+  +tittel : string
+  +offentligTittel : string [0..1]
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +forfatter : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+
+  -- Registrering --
+  +arkivertDato : datetime [0..1]
+  +arkivertAv : string [0..1]
+  +referanseArkivertAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseArkivdel : SystemID [0..1]
+
+  -- Arkivenhet --
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-journalpost.iuml
+++ b/media/uml-class-journalpost.iuml
@@ -1,0 +1,21 @@
+@startuml
+class Sakarkiv.Journalpost <Basisregistrering> {
+  +journalår : integer [0..1]
+  +journalsekvensnummer : integer [0..1]
+  +journalpostnummer : integer [0..1]
+  +journalposttype : Journalposttype
+  +journalstatus : Journalstatus
+  +journaldato : date
+  +dokumentetsDato : date [0..1]
+  +mottattDato : date [0..1]
+  +sendtDato : date [0..1]
+  +forfallsdato : date [0..1]
+  +offentlighetsvurdertDato : date [0..1]
+  +antallVedlegg : integer [0..1]
+  +utlåntDato : date [0..1]
+  +utlåntTil : string [0..1]
+  +referanseUtlåntTil : SystemID [0..1]
+  +journalenhet : string [0..1]
+  +elektroniskSignatur : ElektroniskSignatur [0..1]
+}
+@enduml

--- a/media/uml-class-klasse.iuml
+++ b/media/uml-class-klasse.iuml
@@ -1,0 +1,13 @@
+@startuml
+class Arkivstruktur.Klasse <Arkivenhet> {
+  +klasseID : string
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +skjerming : Skjerming [0..1]
+  +kassasjon : Kassasjon [0..1]
+}
+@enduml

--- a/media/uml-class-klassifikasjonssystem.iuml
+++ b/media/uml-class-klassifikasjonssystem.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Arkivstruktur.Klassifikasjonssystem <Arkivenhet> {
+  +klassifikasjonstype : Klassifikasjonstype [0..1]
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-konvertering.iuml
+++ b/media/uml-class-konvertering.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Arkivstruktur.Konvertering {
+  +systemID : SystemID [0..1]
+  +konvertertDato : datetime
+  +konvertertAv : string
+  +konvertertFraFormat : string
+  +konvertertTilFormat : string
+  +konverteringsverktøy : string [0..1]
+  +konverteringskommentar : string [0..1]
+}
+@enduml

--- a/media/uml-class-korrespondansepart.iuml
+++ b/media/uml-class-korrespondansepart.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Sakarkiv.Korrespondansepart {
+  +systemID : SystemID [0..1]
+  +korrespondanseparttype : Korrespondanseparttype
+  +virksomhetsspesifikkeMetadata : any [0..1]
+}
+@enduml

--- a/media/uml-class-korrespondansepartenhet.iuml
+++ b/media/uml-class-korrespondansepartenhet.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Sakarkiv.KorrespondansepartEnhet <Korrespondansepart> {
+  +organisasjonsnummer : string [0..1]
+  +navn : string
+  +forretningsadresse : EnkelAdresse [0..1]
+  +postadresse : EnkelAdresse [0..1]
+  +kontaktinformasjon : Kontaktinformasjon [0..1]
+  +kontaktperson : string [0..1]
+}
+@enduml

--- a/media/uml-class-korrespondansepartintern.iuml
+++ b/media/uml-class-korrespondansepartintern.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Sakarkiv.KorrespondansepartIntern <Korrespondansepart> {
+  +administrativEnhet : string [0..1]
+  +referanseAdministrativEnhet : SystemID [0..1]
+  +saksbehandler : string [0..1]
+  +referanseSaksbehandler : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-korrespondansepartperson.iuml
+++ b/media/uml-class-korrespondansepartperson.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Sakarkiv.KorrespondansepartPerson <Korrespondansepart> {
+  +fødselsnummer : string [0..1]
+  +DNummer : string [0..1]
+  +navn : string
+  +postadresse : EnkelAdresse [0..1]
+  +bostedsadresse : EnkelAdresse [0..1]
+  +kontaktinformasjon : Kontaktinformasjon [0..1]
+}
+@enduml

--- a/media/uml-class-kryssreferanse.iuml
+++ b/media/uml-class-kryssreferanse.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Arkivstruktur.Kryssreferanse {
+  +referanseTilMappe : SystemID [0..1]
+  +referanseTilKlasse : SystemID [0..1]
+  +referanseTilRegistrering : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-mappe-all.iuml
+++ b/media/uml-class-mappe-all.iuml
@@ -1,0 +1,29 @@
+@startuml
+class Arkivstruktur.Mappe <Arkivenhet> {
+  +mappeID : string [0..1]
+  +mappetype : Mappetype [0..1]
+  +tittel : string
+  +offentligTittel : string [0..1]
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseForelderMappe : SystemID [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+
+  --Arkivenhet--
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-mappe.iuml
+++ b/media/uml-class-mappe.iuml
@@ -1,0 +1,20 @@
+@startuml
+class Arkivstruktur.Mappe <Arkivenhet> {
+  +mappeID : string [0..1]
+  +mappetype : Mappetype [0..1]
+  +tittel : string
+  +offentligTittel : string [0..1]
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseForelderMappe : SystemID [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+}
+@enduml

--- a/media/uml-class-merknad.iuml
+++ b/media/uml-class-merknad.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Arkivstruktur.Merknad {
+  +systemID : SystemID [0..1]
+  +merknadstekst : string
+  +merknadstype : Merknadstype [0..1]
+  +merknadsdato : datetime
+  +merknadRegistrertAv : string [0..1]
+  +referanseMerknadRegistrertAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-presedens.iuml
+++ b/media/uml-class-presedens.iuml
@@ -1,0 +1,20 @@
+@startuml
+class Sakarkiv.Presedens {
+  +systemID : SystemID [0..1]
+  +presedensDato : date
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +presedensHjemmel : string [0..1]
+  +rettskildefaktor : string
+  +presedensGodkjentDato : datetime [0..1]
+  +presedensGodkjentAv : string [0..1]
+  +referansePresedensGodkjentAv : SystemID [0..1]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +presedensStatus : Presedensstatus [0..1]
+}
+@enduml

--- a/media/uml-class-registrering.iuml
+++ b/media/uml-class-registrering.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Arkivstruktur.Registrering <Arkivenhet> {
+  +arkivertDato : datetime [0..1]
+  +arkivertAv : string [0..1]
+  +referanseArkivertAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseArkivdel : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-saksmappe-all.iuml
+++ b/media/uml-class-saksmappe-all.iuml
@@ -1,0 +1,43 @@
+@startuml
+class Sakarkiv.Saksmappe <Mappe> {
+  +saksår : integer [0..1]
+  +sakssekvensnummer : integer [0..1]
+  +saksdato : date
+  +administrativEnhet : string [0..1]
+  +referanseAdministrativEnhet : SystemID [0..1]
+  +saksansvarlig : string
+  +referanseSaksansvarlig : SystemID [0..1]
+  +journalenhet : string [0..1]
+  +saksstatus : Saksstatus
+  +utlåntDato : date [0..1]
+  +utlanttil : string [0..1]
+  +referanseUtlåntTil : SystemID [0..1]
+  
+  .. Mappe ..
+  +mappeID : string [0..1]
+  +mappetype : Mappetype [0..1]
+  +tittel : string
+  +offentligTittel : string [0..1]
+  +beskrivelse : string [0..1]
+  +nøkkelord : string [0..*]
+  +dokumentmedium : Dokumentmedium [0..1]
+  +oppbevaringssted : string [0..*]
+  +avsluttetDato : datetime [0..1]
+  +avsluttetAv : string [0..1]
+  +referanseAvsluttetAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseForelderMappe : SystemID [0..1]
+  +virksomhetsspesifikkeMetadata : any [0..1]
+  
+  .. Arkivenhet ..
+  +systemID : SystemID [0..1]
+  +oppdatertDato : datetime [0..1]
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string [0..1]
+  +referanseOppdatertAv : SystemID [0..1]
+  +referanseOpprettetAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-saksmappe.iuml
+++ b/media/uml-class-saksmappe.iuml
@@ -1,0 +1,16 @@
+@startuml
+class Sakarkiv.Saksmappe <Mappe> {
+  +saksår : integer [0..1]
+  +sakssekvensnummer : integer [0..1]
+  +saksdato : date
+  +administrativEnhet : string [0..1]
+  +referanseAdministrativEnhet : SystemID [0..1]
+  +saksansvarlig : string
+  +referanseSaksansvarlig : SystemID [0..1]
+  +journalenhet : string [0..1]
+  +saksstatus : Saksstatus
+  +utlåntDato : date [0..1]
+  +utlåntTil : string [0..1]
+  +referanseUtlåntTil : SystemID [0..1]
+}
+@enduml

--- a/media/uml-class-sakspart.iuml
+++ b/media/uml-class-sakspart.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Sakarkiv.Sakspart {
+  +systemID : SystemID [0..1]
+  +sakspartRolle : SakspartRolle
+  +virksomhetsspesifikkeMetadata : any [0..1]
+}
+@enduml

--- a/media/uml-class-sakspartenhet.iuml
+++ b/media/uml-class-sakspartenhet.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Sakarkiv.SakspartEnhet <Sakspart> {
+  +organisasjonsnummer : string [0..1]
+  +navn : string
+  +forretningsadresse : EnkelAdresse [0..1]
+  +postadresse : EnkelAdresse [0..1]
+  +kontaktinformasjon : Kontaktinformasjon [0..1]
+  +kontaktperson : string [0..1]
+}
+@enduml

--- a/media/uml-class-sakspartperson.iuml
+++ b/media/uml-class-sakspartperson.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Sakarkiv.SakspartPerson <Sakspart> {
+  +fødselsnummer : string [0..1]
+  +DNummer : string [0..1]
+  +navn : string
+  +postadresse : EnkelAdresse [0..1]
+  +bostedsadresse : EnkelAdresse [0..1]
+  +kontaktinformasjon : Kontaktinformasjon [0..1]
+}
+@enduml

--- a/media/uml-class-tilgang.iuml
+++ b/media/uml-class-tilgang.iuml
@@ -1,0 +1,13 @@
+@startuml
+class Admin.Tilgang {
+  +systemID : SystemID [0..1]
+  +rolle : string
+  +tilgangskategori : Tilgangskategori
+  +referanseArkivenhet : SystemID [0..1]
+  +tilgangsrestriksjon : Tilgangsrestriksjon
+  +les : boolean
+  +ny : boolean
+  +endre : boolean
+  +slett : boolean
+}
+@enduml

--- a/media/uml-codelist-arkivdelstatus.iuml
+++ b/media/uml-codelist-arkivdelstatus.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Kodelister.Arkivdelstatus <<codelist>> {
+  +Aktiv periode = A
+  +Overlappingsperiode = O
+  +Avsluttet periode = P
+  +Uaktuelle mapper = U
+}
+@enduml

--- a/media/uml-codelist-arkivstatus.iuml
+++ b/media/uml-codelist-arkivstatus.iuml
@@ -1,0 +1,6 @@
+@startuml
+class Kodelister.Arkivstatus <<codelist>> {
+  +Opprettet = O
+  +Avsluttet = A
+}
+@enduml

--- a/media/uml-codelist-avskrivningsmaate.iuml
+++ b/media/uml-codelist-avskrivningsmaate.iuml
@@ -1,0 +1,9 @@
+@startuml
+class Kodelister.Avskrivningsmåte <<codelist>> {
+  +Besvart med brev = BU
+  +Besvart med e-post = BE
+  +Besvart på telefon = TLF
+  +Tatt til etterretning = TE
+  +Tatt til orientering = TO
+}
+@enduml

--- a/media/uml-codelist-dokumentmedium.iuml
+++ b/media/uml-codelist-dokumentmedium.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Kodelister.Dokumentmedium <<codelist>> {
+  +Fysisk medium = F
+  +Elektronisk arkiv = E
+  +Blandet fysisk og elektronisk arkiv = B
+}
+@enduml

--- a/media/uml-codelist-dokumentstatus.iuml
+++ b/media/uml-codelist-dokumentstatus.iuml
@@ -1,0 +1,6 @@
+@startuml
+class Kodelister.Dokumentstatus <<codelist>> {
+  +Dokumentet er under redigering = B
+  +Dokumentet er ferdigstilt = F
+}
+@enduml

--- a/media/uml-codelist-dokumenttype.iuml
+++ b/media/uml-codelist-dokumenttype.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Kodelister.Dokumenttype <<codelist>> {
+  +Brev = B
+  +Rundskriv = R
+  +Faktura = F
+  +Ordrebekreftelse = O
+}
+@enduml

--- a/media/uml-codelist-elektronisksignaturverifisert.iuml
+++ b/media/uml-codelist-elektronisksignaturverifisert.iuml
@@ -1,0 +1,6 @@
+@startuml
+class Kodelister.ElektroniskSignaturVerifisert <<codelist>> {
+  +Signatur påført, ikke verifisert = I
+  +Signatur påført og verifisert = V
+}
+@enduml

--- a/media/uml-codelist-flytstatus.iuml
+++ b/media/uml-codelist-flytstatus.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Kodelister.FlytStatus <<codelist>> {
+  +Godkjent = G
+  +Ikke godkjent = I
+  +Sendt tilbake til saksbehandler med kommentarer = S
+}
+@enduml

--- a/media/uml-codelist-format.iuml
+++ b/media/uml-codelist-format.iuml
@@ -1,0 +1,12 @@
+@startuml
+class Kodelister.Format <<codelist>> {
+  +Ren tekst = RA-TEKST
+  +TIFF versjon 6 = RA-TIFF6
+  +PDF/A - ISO 19005-1:2005 = RA-PDF
+  +XML = RA-XML
+  +JPEG = RA-JPEG
+  +SOSI = RA-SOSI
+  +MPEG-2 = RA-MPEG-2
+  +MP3 = RA-MP3
+}
+@enduml

--- a/media/uml-codelist-graderingskode.iuml
+++ b/media/uml-codelist-graderingskode.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Kodelister.Graderingskode <<codelist>> {
+  {field} +Strengt hemmelig (sikkerhetsgrad) = SH
+  {field} +Hemmelig (sikkerhetsgrad) = H
+  {field} +Konfidensielt (sikkerhetsgrad) = K
+  {field} +Begrenset (sikkerhetsgrad) = B
+  {field} +Fortrolig (beskyttelsesgrad) = F
+  {field} +Strengt fortrolig (beskyttelsesgrad) = SF
+}
+@enduml

--- a/media/uml-codelist-hendelsetype.iuml
+++ b/media/uml-codelist-hendelsetype.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Kodelister.Hendelsetype <<codelist>> {
+  +Endringslogg
+  +Søknad mottatt
+  +Søknad komplett
+  +Vedtak
+}
+@enduml

--- a/media/uml-codelist-journalposttype.iuml
+++ b/media/uml-codelist-journalposttype.iuml
@@ -1,0 +1,9 @@
+@startuml
+class Kodelister.Journalposttype <<codelist>> {
+  +Inngående dokument = I
+  +Utgående dokument = U
+  +Organinternt dokument for oppfølging = N
+  +Organinternt dokument uten oppfølging = X
+  +Saksframlegg = S
+}
+@enduml

--- a/media/uml-codelist-journalstatus.iuml
+++ b/media/uml-codelist-journalstatus.iuml
@@ -1,0 +1,13 @@
+@startuml
+class Kodelister.Journalstatus <<codelist>> {
+  +Journalført = J
+  +Ferdigstilt fra saksbehandler = F
+  +Godkjent av leder = G
+  +Ekspedert = E
+  +Arkivert = A
+  +Utgår = U
+  +Midlertidig registrering av innkommet dokument = M
+  +Saksbehandler har registrert innkommet dokument = S
+  +Reservert dokument = R
+}
+@enduml

--- a/media/uml-codelist-kassasjonsvedtak.iuml
+++ b/media/uml-codelist-kassasjonsvedtak.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Kodelister.Kassasjonsvedtak <<codelist>> {
+  +Bevares = B
+  +Kasseres = K
+  +Vurderes senere = G
+}
+@enduml

--- a/media/uml-codelist-klassifikasjonstype.iuml
+++ b/media/uml-codelist-klassifikasjonstype.iuml
@@ -1,0 +1,12 @@
+@startuml
+class Kodelister.Klassifikasjonstype <<codelist>> {
+  +Gårds- og bruksnummer = GBN
+  +Funksjonsbasert, hierarkisk = FH
+  +Emnebasert, hierarkisk arkivnøkkel = EH
+  +Emnebasert, ett nivå = E1
+  +K-koder = KK
+  +Mangefasettert, ikke hierarki = MF
+  +Objektbasert = UO
+  +Fødselsnummer = PNR
+}
+@enduml

--- a/media/uml-codelist-korrespondanseparttype.iuml
+++ b/media/uml-codelist-korrespondanseparttype.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Kodelister.Korrespondanseparttype <<codelist>> {
+  +Avsender = EA
+  +Mottaker = EM
+  +Kopimottaker = EK
+  +Gruppemottaker = GM
+  +Intern avsender = IA
+  +Intern mottaker = IM
+  +Intern kopimottaker = IK
+}
+@enduml

--- a/media/uml-codelist-land.iuml
+++ b/media/uml-codelist-land.iuml
@@ -1,0 +1,4 @@
+@startuml
+class Kodelister.Land <<codelist>> {
+}
+@enduml

--- a/media/uml-codelist-mappetype.iuml
+++ b/media/uml-codelist-mappetype.iuml
@@ -1,0 +1,4 @@
+@startuml
+class Kodelister.Mappetype <<codelist>> {
+}
+@enduml

--- a/media/uml-codelist-merknadstype.iuml
+++ b/media/uml-codelist-merknadstype.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Kodelister.Merknadstype <<codelist>> {
+  +Merknad fra saksbehandler = MS
+  +Merknad fra leder = ML
+  +Merknad fra arkivansvarlig = MA
+}
+@enduml

--- a/media/uml-codelist-postnummer.iuml
+++ b/media/uml-codelist-postnummer.iuml
@@ -1,0 +1,4 @@
+@startuml
+class Kodelister.Postnummer <<codelist>> {
+}
+@enduml

--- a/media/uml-codelist-presedensstatus.iuml
+++ b/media/uml-codelist-presedensstatus.iuml
@@ -1,0 +1,6 @@
+@startuml
+class Kodelister.Presedensstatus <<codelist>> {
+  +Gjeldende = G
+  +Foreldet = F
+}
+@enduml

--- a/media/uml-codelist-sakspartrolle.iuml
+++ b/media/uml-codelist-sakspartrolle.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Kodelister.SakspartRolle <<codelist>> {
+  +Klient = KLI
+  +Pårørende = PÅ
+  +Formynder = FORM
+  +Advokat = ADV
+}
+@enduml

--- a/media/uml-codelist-saksstatus.iuml
+++ b/media/uml-codelist-saksstatus.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Kodelister.Saksstatus <<codelist>> {
+  +Under behandling = B
+  +Avsluttet = A
+  +Utgår = U
+  +Opprettet av saksbehandler = R
+  +Avsluttet av saksbehandler = S
+  +Unntatt prosesstyring = P
+  +Ferdig fra saksbehandler = F
+}
+@enduml

--- a/media/uml-codelist-skjermingdokument.iuml
+++ b/media/uml-codelist-skjermingdokument.iuml
@@ -1,0 +1,6 @@
+@startuml
+class Kodelister.SkjermingDokument <<codelist>> {
+  +Skjerming av hele dokumentet = H
+  +Skjerming av deler av dokumentet = D
+}
+@enduml

--- a/media/uml-codelist-skjermingmetadata.iuml
+++ b/media/uml-codelist-skjermingmetadata.iuml
@@ -1,0 +1,16 @@
+@startuml
+class Kodelister.SkjermingMetadata <<codelist>> {
+  +Skjerming klasseID = KID
+  +Skjerming tittel klasse = TKL
+  +Skjerming tittel mappe - unntatt første linje = TM1
+  +Skjerming tittel mappe - utvalgte ord = TMO
+  +Skjerming navn part i sak = NPS
+  +Skjerming tittel registrering - unntatt første linje = TR1
+  +Skjerming tittel registrering - utvalgte ord = TRO
+  +Skjerming navn avsender = NA
+  +Skjerming navn mottaker = NM
+  +Skjerming tittel dokumentbeskrivelse = TD
+  +Skjerming merknadstekst = MT
+  +Midlertidig skjerming = M
+}
+@enduml

--- a/media/uml-codelist-slettingstype.iuml
+++ b/media/uml-codelist-slettingstype.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Kodelister.Slettingstype <<codelist>> {
+  +Sletting av produksjonsformat = SP
+  +Sletting av tidligere versjon = SV
+  +Sletting av variant med sladdet informasjon = SS
+  +Sletting av hele innholdet i arkivdelen = SA
+}
+@enduml

--- a/media/uml-codelist-tilgangskategori.iuml
+++ b/media/uml-codelist-tilgangskategori.iuml
@@ -1,0 +1,9 @@
+@startuml
+class Kodelister.Tilgangskategori <<codelist>> {
+  +arkivdel = A
+  +klasse = K
+  +mappe = M
+  +registrering = R
+  +dokumentbeskrivelse = D
+}
+@enduml

--- a/media/uml-codelist-tilgangsrestriksjon.iuml
+++ b/media/uml-codelist-tilgangsrestriksjon.iuml
@@ -1,0 +1,16 @@
+@startuml
+class Kodelister.Tilgangsrestriksjon <<codelist>> {
+  +Begrenset etter sikkerhetsinstruksen = B
+  +Konfidensielt etter sikkerhetsinstruksen = K
+  +Hemmelig etter sikkerhetsinstruksen = H
+  +Fortrolig etter beskyttelsesinstruksen = F
+  +Strengt fortrolig etter beskyttelsesinstruksen = SF
+  +Unntatt etter offentlighetsloven § 5 = 5
+  +Unntatt etter offentlighetsloven § 5a = 5a
+  +Unntatt etter offentlighetsloven § 6 = 6
+  +Unntatt etter offentlighetsloven § 11 = 11
+  +Midlertidig sperret = XX
+  +Personalsaker = P
+  +Klientsaker = KL
+}
+@enduml

--- a/media/uml-codelist-tilknyttetregistreringsom.iuml
+++ b/media/uml-codelist-tilknyttetregistreringsom.iuml
@@ -1,0 +1,6 @@
+@startuml
+class Kodelister.TilknyttetRegistreringSom <<codelist>> {
+  +Hoveddokument = H
+  +Vedlegg = V
+}
+@enduml

--- a/media/uml-codelist-variantformat.iuml
+++ b/media/uml-codelist-variantformat.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Kodelister.Variantformat <<codelist>> {
+  +Produksjonsformat = P
+  +Arkivformat = A
+  +Dokument hvor deler av innholdet er skjermet = O
+}
+@enduml

--- a/media/uml-datatype-elektronisksignatur.iuml
+++ b/media/uml-datatype-elektronisksignatur.iuml
@@ -1,0 +1,9 @@
+@startuml
+class Arkivstruktur.ElektroniskSignatur <<dataType>> {
+  +elektroniskSignaturSikkerhetsnivå : ElektroniskSignaturSikkerhetsnivå
+  +elektroniskSignaturVerifisert : ElektroniskSignaturVerifisert
+  +verifisertDato : date
+  +verifisertAv : string
+  +referanseVerifisertAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-datatype-enkeladresse.iuml
+++ b/media/uml-datatype-enkeladresse.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Sakarkiv.EnkelAdresse <<dataType>> {
+  +adresselinje1 : string [0..1]
+  +adresselinje2 : string [0..1]
+  +adresselinje3 : string [0..1]
+  +postnr : Postnummer [0..1]
+  +poststed : string
+  +landkode : Land [0..1]
+}
+@enduml

--- a/media/uml-datatype-gradering.iuml
+++ b/media/uml-datatype-gradering.iuml
@@ -1,0 +1,11 @@
+@startuml
+class Arkivstruktur.Gradering <<dataType>> {
+  +graderingskode : Graderingskode
+  +graderingsdato : datetime
+  +gradertAv : string
+  +referanseGradertAv : SystemID
+  +nedgraderingsdato : datetime [0..1]
+  +nedgradertAv : string [0..1]
+  +referanseNedgradertAv : SystemID [0..1]
+}
+@enduml

--- a/media/uml-datatype-kassasjon.iuml
+++ b/media/uml-datatype-kassasjon.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Arkivstruktur.Kassasjon <<dataType>> {
+  +kassasjonsvedtak : Kassasjonsvedtak
+  +kassasjonshjemmel : string [0..1]
+  +bevaringstid : integer
+  +kassasjonsdato : date
+}
+@enduml

--- a/media/uml-datatype-kontaktinformasjon.iuml
+++ b/media/uml-datatype-kontaktinformasjon.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Sakarkiv.Kontaktinformasjon <<dataType>> {
+  +epostadresse : string [0..1]
+  +mobiltelefon : string [0..1]
+  +telefon : string [0..1]
+}
+@enduml

--- a/media/uml-datatype-skjerming.iuml
+++ b/media/uml-datatype-skjerming.iuml
@@ -1,0 +1,10 @@
+@startuml
+class Arkivstruktur.Skjerming <<dataType>> {
+  +tilgangsrestriksjon : Tilgangsrestriksjon
+  +skjermingshjemmel : string
+  +skjermingMetadata : SkjermingMetadata [0..*]
+  +skjermingDokument : SkjermingDokument [0..1]
+  +skjermingsvarighet : integer [0..1]
+  +skjermingOpphørerDato : date [0..1]
+}
+@enduml

--- a/media/uml-datatype-sletting.iuml
+++ b/media/uml-datatype-sletting.iuml
@@ -1,0 +1,8 @@
+@startuml
+class Arkivstruktur.Sletting <<dataType>> {
+  +slettingstype : Slettingstype
+  +slettetDato : datetime
+  +slettetAv : string
+  +referanseSlettetAv : SystemID
+}
+@enduml

--- a/media/uml-datatype-utfoertkassasjon.iuml
+++ b/media/uml-datatype-utfoertkassasjon.iuml
@@ -1,0 +1,7 @@
+@startuml
+class Arkivstruktur.UtførtKassasjon <<dataType>> {
+  +kassertDato : datetime
+  +kassertAv : string
+  +referanseKassertAv : SystemID
+}
+@enduml

--- a/media/uml-elektronisk-signatur.puml
+++ b/media/uml-elektronisk-signatur.puml
@@ -1,0 +1,13 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-journalpost.iuml
+!include media/uml-datatype-elektronisksignatur.iuml
+!include media/uml-class-dokumentbeskrivelse.iuml
+!include media/uml-class-dokumentobjekt.iuml
+
+Arkivstruktur.ElektroniskSignatur -[hidden]-> Sakarkiv.Journalpost
+Arkivstruktur.ElektroniskSignatur --[hidden]-> Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Dokumentobjekt <-[hidden]- Arkivstruktur.ElektroniskSignatur
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o-> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+@enduml

--- a/media/uml-endringslogg.puml
+++ b/media/uml-endringslogg.puml
@@ -1,0 +1,13 @@
+@startuml
+skinparam classAttributeIconSize 0
+class Arkivstruktur.Endringslogg {
+  +systemID : SystemID [0..1]
+  +referanseArkivenhet : SystemID [0..1]
+  +referanseMetadata : string [0..1]
+  +endretDato : datetime
+  +endretAv : string
+  +referanseEndretAv : string
+  +tidligereVerdi : string [0..1]
+  +nyVerdi : string [0..1]
+}
+@enduml

--- a/media/uml-forklaring-om-notasjon-som-er-brukt.puml
+++ b/media/uml-forklaring-om-notasjon-som-er-brukt.puml
@@ -1,0 +1,67 @@
+@startuml
+skinparam classAttributeIconSize 0
+'FIXME dropped caption "class Klassediagram_forklaring"
+class Albumenhet {
+  +systemID : SystemID
+  +oppdatertDato : datetime
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +oppdatertAv : string
+  +referanseOpprettetAv : SystemID [0..1]
+}
+class Foto {
+  +systemID : SystemID
+  +versjonsnummer : integer
+  +format : Format
+  +opprettetDato : datetime [0..1]
+  +opprettetAv : string [0..1]
+  +filstørrelse : string
+  -- constraints --
+  {Det skal finnesvære mulig å |formattesting}
+  {M001 systemID: Skal ikke kunne endres}
+  -- notes --
+  Her kan de lages en forklaring om hva
+  denne klassen skal brukes til
+}
+Albumenhet "0..*" *-> "+foto 1..*" Foto
+class Fil {
+  +filnavn : string
+  +mimeType : string
+}
+Foto --> "+fotofil 0..1" Fil
+note bottom of Fil : Dette er eksempel på en\nnote, som kan være\nknytta til en klasse (som\ndenne) eller kan være\n"løs"
+
+class Fotoalbum {
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +oppbevaringssted : string [0..*]
+}
+class Albumdel {
+  +tittel : string
+  +beskrivelse : string [0..1]
+  +oppbevaringssted : string [0..*]
+  +gradering : Gradering [0..1]
+}
+Fotoalbum "+underalbum 0..*" --o Fotoalbum
+Fotoalbum "+album 1" o- "+albumdel 0..*" Albumdel
+Albumenhet <|-- Fotoalbum
+Albumenhet <|-- Albumdel
+
+!include media/uml-datatype-gradering.iuml
+!include media/uml-codelist-graderingskode.iuml
+
+'FIXME figure out if two SystemID classes can co-exist
+class Arkivstruktur.SystemID <<simple>> {
+  -- notes --
+  Definisjon: Entydig
+  identifikasjon av
+  enheten
+}
+class BasicTypes.string <<simple>>
+class Arkivstruktur.SystemID <<simple>>
+BasicTypes.string <|-- Arkivstruktur.SystemID
+'layout adjustments
+Fotoalbum <-[hidden]- Arkivstruktur.Gradering
+Arkivstruktur.Gradering <-[hidden]- Kodelister.Graderingskode
+Albumdel <-[hidden]- BasicTypes.string
+@enduml

--- a/media/uml-generalisering-brukt-med-klasser.puml
+++ b/media/uml-generalisering-brukt-med-klasser.puml
@@ -1,0 +1,8 @@
+@startuml
+'FIXME dropped caption "class Fig04_Generalisering"
+class Basisregistrering < Registrering >
+class Journalpost < Basisregistrering >
+class Møteregistrering < Basisregistrering >
+Basisregistrering <|-- Journalpost
+Basisregistrering <|-- Møteregistrering
+@enduml

--- a/media/uml-hovedmodell-saksbehandling.puml
+++ b/media/uml-hovedmodell-saksbehandling.puml
@@ -1,0 +1,39 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+class Arkivstruktur.Arkiv <Arkivenhet>
+class Arkivstruktur.Arkivdel <Arkivenhet>
+class Arkivstruktur.Klassifikasjonssystem <Arkivenhet>
+class Arkivstruktur.Klasse <Arkivenhet>
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+class Sakarkiv.Saksmappe #pink
+class Sakarkiv.Presedens #pink
+class Sakarkiv.Journalpost #pink
+class Sakarkiv.Avskrivning #pink
+class Sakarkiv.Dokumentflyt #pink
+
+Arkivstruktur.Arkiv o-> "+underarkiv 0..*" Arkivstruktur.Arkiv
+Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivdel "+arkivdel 1..*" o--> "+klassifikasjonssystem 0..1" Arkivstruktur.Klassifikasjonssystem
+Arkivstruktur.Arkivdel o--> "+sekundærklassifikasjonssystem 0..*" Arkivstruktur.Klassifikasjonssystem
+Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o--> "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse o--> "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o--> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
+Arkivstruktur.Klasse "\n\n+sekundærklassifikasjon\n0..*" <--o Sakarkiv.Saksmappe
+Arkivstruktur.Mappe "mappe 0..1" o--> "+registrering 0..*\n\n" Arkivstruktur.Registrering
+Arkivstruktur.Mappe "mappe 0..*\n\n" <--o "+arkivdel 0..1" Arkivstruktur.Arkivdel
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+Arkivstruktur.Registrering "+registrering 0..*" <--o "+arkivdel 0..1" Arkivstruktur.Arkivdel
+Arkivstruktur.Registrering <|-- Arkivstruktur.Basisregistrering
+Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt
+Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+Sakarkiv.Presedens "+presedens 0..*" <--o "+journalpost 0..*" Sakarkiv.Journalpost
+Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
+Sakarkiv.Journalpost *--> "+dokumentflyt 0..*" Sakarkiv.Dokumentflyt
+@enduml

--- a/media/uml-journalpost.puml
+++ b/media/uml-journalpost.puml
@@ -1,0 +1,19 @@
+@startuml
+skinparam classAttributeIconSize 0
+!include media/uml-class-journalpost-all.iuml
+!include media/uml-class-korrespondansepart.iuml
+!include media/uml-class-presedens.iuml
+!include media/uml-class-avskrivning.iuml
+!include media/uml-class-dokumentflyt.iuml
+!include media/uml-codelist-journalposttype.iuml
+!include media/uml-codelist-journalstatus.iuml
+!include media/uml-codelist-flytstatus.iuml
+
+Kodelister.FlytStatus <-[hidden]-- Sakarkiv.Dokumentflyt
+Sakarkiv.Dokumentflyt "+dokumentflyt 0..*" <--* Sakarkiv.Journalpost
+Sakarkiv.Korrespondansepart "+korrespondansepart 0..*" <--* Sakarkiv.Journalpost
+Sakarkiv.Presedens "+presedens 0..*" <--o "+journalpost 0..*" Sakarkiv.Journalpost
+Sakarkiv.Journalpost *-> "+avskrivning 0..*" Sakarkiv.Avskrivning
+Sakarkiv.Journalpost <-[hidden]-- Kodelister.Journalposttype
+Sakarkiv.Journalpost <-[hidden]-- Kodelister.Journalstatus
+@enduml

--- a/media/uml-klasse-avskrivning.puml
+++ b/media/uml-klasse-avskrivning.puml
@@ -1,0 +1,18 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-journalpost-all.iuml
+!include media/uml-class-korrespondansepart.iuml
+!include media/uml-class-korrespondansepartperson.iuml
+!include media/uml-class-korrespondansepartenhet.iuml
+!include media/uml-class-korrespondansepartintern.iuml
+!include media/uml-class-avskrivning.iuml
+!include media/uml-codelist-avskrivningsmaate.iuml
+
+Sakarkiv.Journalpost *-> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartPerson
+Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartEnhet
+Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartIntern
+Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
+Sakarkiv.Avskrivning <-[hidden]- Kodelister.Avskrivningsmåte
+@enduml

--- a/media/uml-klasse-http-metoder.puml
+++ b/media/uml-klasse-http-metoder.puml
@@ -1,0 +1,14 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+package "class Tjenester" <<Frame>> {
+
+class REST-tjenester << interface >> {
+  +GET (Request) : Response
+  +PUT (Request) : Reponse
+  +POST (Request) : Response
+  +DELETE (Request) : Response
+}
+
+}
+@enduml

--- a/media/uml-klasse-konseptet-og-bruken-av-stereotyper.puml
+++ b/media/uml-klasse-konseptet-og-bruken-av-stereotyper.puml
@@ -1,0 +1,9 @@
+@startuml
+skinparam classAttributeIconSize 0
+'FIXME dropped caption "class Fig02_Stereotyper"
+
+!include media/uml-datatype-gradering.iuml
+!include media/uml-codelist-graderingskode.iuml
+
+Arkivstruktur.Gradering -[hidden]-> Kodelister.Graderingskode
+@enduml

--- a/media/uml-klasse-konspetet-bruker-registrering-som-eksempel.puml
+++ b/media/uml-klasse-konspetet-bruker-registrering-som-eksempel.puml
@@ -1,0 +1,19 @@
+@startuml
+skinparam classAttributeIconSize 0
+'FIXME dropped caption "class Fig01_Klasse"
+class Arkivstruktur.Registrering < Arkivenhet > {
+  +arkivertDato : datetime [0..1]
+  +arkivertAv : string [0..1]
+  +referanseArkivertAv : SystemID [0..1]
+  +kassasjon : Kassasjon [0..1]
+  +skjerming : Skjerming [0..1]
+  +gradering : Gradering [0..1]
+  +referanseArkivdel : SystemID [0..1]
+
+  __ notes __
+  En registrering inneholder bare de metadata som
+  er nødvendig dersom dokumentet arkiveres uten
+  journalføring.  Dette kalles også forenklet
+  registrering
+}
+@enduml

--- a/media/uml-klasse-person-og-organisasjonsdata.puml
+++ b/media/uml-klasse-person-og-organisasjonsdata.puml
@@ -1,0 +1,49 @@
+@startuml
+class Sakarkiv.Journalpost <Basisregistrering>
+
+!include media/uml-codelist-korrespondanseparttype.iuml
+!include media/uml-class-korrespondansepart.iuml
+!include media/uml-class-korrespondansepartintern.iuml
+!include media/uml-class-korrespondansepartperson.iuml
+!include media/uml-class-korrespondansepartenhet.iuml
+
+Sakarkiv.Journalpost *- "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Sakarkiv.Korrespondansepart <-[hidden]- Kodelister.Korrespondanseparttype
+Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartPerson
+Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartEnhet
+Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartIntern
+
+note "ISO liste" as isoliste
+note "fra posten.no" as fraposten
+class Kodelister.Land <<codelist>>
+class Kodelister.Postnummer <<codelist>>
+Sakarkiv.EnkelAdresse <-[hidden]- Kodelister.Land
+Kodelister.Land .. isoliste
+Sakarkiv.EnkelAdresse <-[hidden]- Kodelister.Postnummer
+Kodelister.Postnummer .. fraposten
+
+!include media/uml-class-administrativenhet.iuml
+!include media/uml-class-bruker.iuml
+
+Sakarkiv.KorrespondansepartIntern <-[hidden]-- Admin.AdministrativEnhet
+Admin.AdministrativEnhet "+enhet 0..*" <--> "+bruker 0..*" Admin.Bruker
+
+!include media/uml-datatype-enkeladresse.iuml
+
+Sakarkiv.KorrespondansepartPerson <-[hidden]-- Sakarkiv.EnkelAdresse
+Sakarkiv.KorrespondansepartEnhet <-[hidden]-- Sakarkiv.EnkelAdresse
+
+!include media/uml-datatype-kontaktinformasjon.iuml
+!include media/uml-class-saksmappe.iuml
+!include media/uml-class-sakspart.iuml
+!include media/uml-class-sakspartperson.iuml
+!include media/uml-class-sakspartenhet.iuml
+
+Sakarkiv.Saksmappe *-- "+sakspart 0..*" Sakarkiv.Sakspart
+Sakarkiv.Sakspart <|-- Sakarkiv.SakspartPerson
+Sakarkiv.Sakspart <|-- Sakarkiv.SakspartEnhet
+Sakarkiv.Saksmappe <-[hidden]- Sakarkiv.Journalpost
+Sakarkiv.SakspartPerson <-[hidden]- Sakarkiv.Kontaktinformasjon
+Sakarkiv.SakspartEnhet <-[hidden]- Sakarkiv.Kontaktinformasjon
+
+@enduml

--- a/media/uml-klasse-saksbehandling.puml
+++ b/media/uml-klasse-saksbehandling.puml
@@ -1,0 +1,24 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-saksmappe-all.iuml
+!include media/uml-class-presedens.iuml
+!include media/uml-class-sakspart.iuml
+!include media/uml-codelist-sakspartrolle.iuml
+!include media/uml-class-journalpost-all.iuml
+!include media/uml-class-korrespondansepart.iuml
+!include media/uml-codelist-korrespondanseparttype.iuml
+!include media/uml-class-avskrivning.iuml
+!include media/uml-codelist-avskrivningsmaate.iuml
+!include media/uml-class-dokumentflyt.iuml
+
+Sakarkiv.Sakspart "+sakspart 0..*" <--* Sakarkiv.Saksmappe
+Kodelister.SakspartRolle <-[hidden]--  Sakarkiv.Sakspart
+Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
+Sakarkiv.Journalpost "+journalpost 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
+Sakarkiv.Journalpost *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Kodelister.Korrespondanseparttype <-[hidden]-- Sakarkiv.Korrespondansepart
+Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
+Kodelister.Avskrivningsmåte  <-[hidden]- Sakarkiv.Avskrivning
+Sakarkiv.Journalpost *-> "+dokumentflyt 0..*" Sakarkiv.Dokumentflyt
+@enduml

--- a/media/uml-kodelister-entiter.puml
+++ b/media/uml-kodelister-entiter.puml
@@ -1,0 +1,70 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-codelist-arkivstatus.iuml
+!include media/uml-codelist-dokumentmedium.iuml
+!include media/uml-codelist-klassifikasjonstype.iuml
+!include media/uml-codelist-merknadstype.iuml
+!include media/uml-codelist-skjermingdokument.iuml
+!include media/uml-codelist-arkivdelstatus.iuml
+!include media/uml-codelist-dokumenttype.iuml
+!include media/uml-codelist-tilknyttetregistreringsom.iuml
+!include media/uml-codelist-format.iuml
+!include media/uml-codelist-dokumentstatus.iuml
+!include media/uml-codelist-skjermingmetadata.iuml
+!include media/uml-codelist-flytstatus.iuml
+!include media/uml-codelist-variantformat.iuml
+!include media/uml-codelist-saksstatus.iuml
+!include media/uml-codelist-korrespondanseparttype.iuml
+!include media/uml-codelist-slettingstype.iuml
+!include media/uml-codelist-journalposttype.iuml
+!include media/uml-codelist-presedensstatus.iuml
+!include media/uml-codelist-avskrivningsmaate.iuml
+!include media/uml-codelist-journalstatus.iuml
+!include media/uml-codelist-kassasjonsvedtak.iuml
+!include media/uml-codelist-graderingskode.iuml
+!include media/uml-codelist-elektronisksignaturverifisert.iuml
+
+class Kodelister.Møtesakstype <<codelist>> {
+  +Politisk sak = PS
+  +Delegert møtesak = DS
+  +Referatsak = RS
+  {field} +Forespørsel (interpellasjon) = FO
+}
+
+class Kodelister.Møteregistreringstype <<codelist>> {
+  +Møteinnkalling = MI
+  +Saksfremlegg = SF
+  +Saksprotokoll = SP
+  +Møteprotokoll = MP
+  +Saksliste = SL
+  +Offentlig saksliste = OL
+  +Vedlegg til møtesak = FL
+}
+
+class Kodelister.ElektroniskSignaturSikkerhetsnivå <<codelist>> {
+  +Symmetrisk kryptert = SK
+  +Sendt med PKI/virksomhetssertifikat = V
+  +Sendt med PKI/"person standard"-sertifikat = PS
+  +Sendt med PKI/"person høy"-sertifikat = PH
+}
+
+!include media/uml-codelist-mappetype.iuml
+!include media/uml-codelist-tilgangskategori.iuml
+
+class Kodelister.Møteregistreringsstatus <<codelist>> {
+  +Ferdig behandlet av utvalget = BE
+  +Utsatt til nytt møte i samme utvalg = UT
+  +Sendt tilbake til foregående utvalg = TB
+}
+
+class Kodelister.MøtedeltakerFunksjon <<codelist>> {
+  +Møteleder = M
+  +Referent = R
+}
+
+!include media/uml-codelist-sakspartrolle.iuml
+!include media/uml-codelist-tilgangsrestriksjon.iuml
+!include media/uml-codelist-land.iuml
+!include media/uml-codelist-postnummer.iuml
+@enduml

--- a/media/uml-komposisjon-brukt-med-klasser.puml
+++ b/media/uml-komposisjon-brukt-med-klasser.puml
@@ -1,0 +1,6 @@
+@startuml
+skinparam classAttributeIconSize 0
+'FIXME dropped caption "class Fig05_Komposisjon"
+!include media/uml-class-basisregistrering.iuml
+Arkivstruktur.Basisregistrering *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+@enduml

--- a/media/uml-metadata-entitet.puml
+++ b/media/uml-metadata-entitet.puml
@@ -1,0 +1,5 @@
+@startuml
+class Arkivstruktur.SystemID << simple >>
+class BasicTypes.string << simple >>
+BasicTypes.string <|-- Arkivstruktur.SystemID
+@enduml

--- a/media/uml-multiplisitet-brukt-med-klasser.puml
+++ b/media/uml-multiplisitet-brukt-med-klasser.puml
@@ -1,0 +1,8 @@
+@startuml
+skinparam classAttributeIconSize 0
+'FIXME dropped caption "class Fig06_Multiplisitet"
+!include media/uml-class-klasse.iuml
+class Arkivstruktur.Mappe <Arkivenhet>
+
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
+@enduml

--- a/media/uml-pakker-og-tilhoerende-klasser.puml
+++ b/media/uml-pakker-og-tilhoerende-klasser.puml
@@ -1,0 +1,227 @@
+@startuml
+hide circle
+hide empty members
+skinparam ranksep 12
+
+package Arkivstruktur <<applicationSchema>> {
+  class Arkiv
+  class Arkivdel
+  abstract class Arkivenhet
+  class Basisregistrering
+  class Dokumentbeskrivelse
+  class Dokumentobjekt
+  class ElektroniskSignatur
+  class Gradering
+  class Hendelseslogg
+  class Kassasjon
+  class Klasse
+  class Klassifikasjonssystem
+  class Konvertering
+  class Kryssreferanse
+  class Mappe
+  class Merknad
+  class Registrering
+  class Skjerming
+  class UtførtKassasjon
+
+  Arkiv -[hidden]- Arkivdel
+  Arkivdel -[hidden]- Arkivenhet
+  Arkivenhet -[hidden]-  Basisregistrering
+  Basisregistrering -[hidden]-  Dokumentbeskrivelse
+  Dokumentbeskrivelse -[hidden]-  Dokumentobjekt
+  Dokumentobjekt -[hidden]-  ElektroniskSignatur
+  ElektroniskSignatur -[hidden]-  Gradering
+  Gradering -[hidden]-  Hendelseslogg
+  Hendelseslogg -[hidden]-  Kassasjon
+  Kassasjon -[hidden]-  Klasse
+  Klasse -[hidden]-  Klassifikasjonssystem
+  Klassifikasjonssystem -[hidden]-  Konvertering
+  Konvertering -[hidden]-  Kryssreferanse
+  Kryssreferanse -[hidden]-  Mappe
+  Mappe -[hidden]-  Merknad
+  Merknad -[hidden]-  Registrering
+  Registrering -[hidden]-  Skjerming
+  Skjerming -[hidden]-  UtførtKassasjon
+  UtførtKassasjon -[hidden]- Bygning
+
+  package NasjonaleIdentifikatorer {
+    class Bygning
+    class Enhetsidentifikator
+    class Matrikkel
+    abstract class NasjonalIdentifikator
+    class Personidentifikator
+    class Plan
+    class Posisjon
+
+    Bygning -[hidden]- Enhetsidentifikator
+    Enhetsidentifikator -[hidden]- Matrikkel
+    Matrikkel -[hidden]- NasjonalIdentifikator
+    NasjonalIdentifikator -[hidden]- Personidentifikator
+    Personidentifikator -[hidden]- Plan
+    Plan -[hidden]- Posisjon
+  }
+}
+package Sakarkiv <<applicationSchema>> {
+  class Avskrivning
+  class Dokumentflyt
+  class EnkelAdresse
+  class Journalpost
+  class Kontaktinformasjon
+  abstract class Korrespondansepart
+  class KorrespondansepartEnhet
+  class KorrespondansepartIntern
+  class KorrespondansepartPerson
+  class Presedens
+  class Saksmappe
+  abstract class Sakspart
+  class SakspartEnhet
+  class SakspartPerson
+
+  Posisjon -[hidden]- Avskrivning
+  Avskrivning -[hidden]- Dokumentflyt
+  Dokumentflyt -[hidden]- EnkelAdresse
+  EnkelAdresse -[hidden]- Journalpost
+  Journalpost -[hidden]- Kontaktinformasjon
+  Kontaktinformasjon -[hidden]- Korrespondansepart
+  Korrespondansepart -[hidden]- KorrespondansepartEnhet
+  KorrespondansepartEnhet -[hidden]- KorrespondansepartIntern
+  KorrespondansepartIntern -[hidden]- KorrespondansepartPerson
+  KorrespondansepartPerson -[hidden]- Presedens
+  Presedens -[hidden]- Saksmappe
+  Saksmappe -[hidden]- Sakspart
+  Sakspart -[hidden]- SakspartEnhet
+  SakspartEnhet -[hidden]- SakspartPerson
+}
+package Admin <<applicationSchema>> {
+  class AdministrativEnhet
+  class Bruker
+  class Tilgang
+
+  AdministrativEnhet -[hidden]- Bruker
+  Bruker --Tilgang
+}
+package LoggingOgSporing <<applicationSchema>> {
+  class EndringsLogg
+
+  Tilgang -[hidden]- EndringsLogg
+}
+package Kodelister <<applicationSchema>> {
+  class Arkivdelstatus
+  class Arkivstatus
+  class Avskrivningsmåte
+  class Dokumentmedium
+  class Dokumentstatus
+  class Dokumenttype
+  class ElektroniskSignaturSikkerhetsnivå
+  class ElektroniskSignaturVerifisert
+  class FlytStatus
+  class Format
+  class Graderingskode
+  class Hendelsetype
+  class Journalposttype
+  class Kassasjonsvedtak
+  class Klassifikajonstype
+  class Korrespondanseparttype
+  class Land
+  class Mappetype
+  class Merknadstype
+  class MøtedeltagerFunksjon
+  class Møteregistreringsstatus
+  class Møteregistreringstype
+  class Møtesakstype
+  class Postnummer
+  class Presedensstatus
+  class Sakspartrolle
+  class Saksstatus
+  class SkjermingDokument
+  class SkjermingMetadata
+  class Slettingstype
+  class SystemID
+  class Tilgangskategori
+  class Tilgangsrestriksjon
+  class TilknyttetRegistreringSom
+  class Variantformat
+
+  Arkivdelstatus -[hidden]- Arkivstatus
+  Arkivstatus -[hidden]- Avskrivningsmåte
+  Avskrivningsmåte -[hidden]- Dokumentmedium
+  Dokumentmedium -[hidden]- Dokumentstatus
+  Dokumentstatus -[hidden]- Dokumenttype
+  Dokumenttype -[hidden]- ElektroniskSignaturSikkerhetsnivå
+  ElektroniskSignaturSikkerhetsnivå -[hidden]- ElektroniskSignaturVerifisert
+  ElektroniskSignaturVerifisert -[hidden]- FlytStatus
+  FlytStatus -[hidden]- Format
+  Format -[hidden]- Graderingskode
+  Graderingskode -[hidden]- Hendelsetype
+  Hendelsetype -[hidden]- Journalposttype
+  Journalposttype -[hidden]- Kassasjonsvedtak
+  Kassasjonsvedtak -[hidden]- Klassifikajonstype
+  Klassifikajonstype -[hidden]- Korrespondanseparttype
+  Korrespondanseparttype -[hidden]- Land
+  Land -[hidden]- Mappetype
+  Mappetype -[hidden]- Merknadstype
+  Merknadstype -[hidden]- MøtedeltagerFunksjon
+  MøtedeltagerFunksjon -[hidden]- Møteregistreringsstatus
+  Møteregistreringsstatus -[hidden]- Møteregistreringstype
+  Møteregistreringstype -[hidden]- Møtesakstype
+  Møtesakstype -[hidden]- Postnummer
+  Postnummer -[hidden]- Presedensstatus
+  Presedensstatus -[hidden]- Sakspartrolle
+  Sakspartrolle -[hidden]- Saksstatus
+  Saksstatus -[hidden]- SkjermingDokument
+  SkjermingDokument -[hidden]- SkjermingMetadata
+  SkjermingMetadata -[hidden]- Slettingstype
+  Slettingstype -[hidden]- SystemID
+  SystemID -[hidden]- Tilgangskategori
+  Tilgangskategori -[hidden]- Tilgangsrestriksjon
+  Tilgangsrestriksjon -[hidden]- TilknyttetRegistreringSom
+  TilknyttetRegistreringSom -[hidden]- Variantformat
+}
+package GeoIntegrasjon {
+
+  package Felles.Geometri <<applicationSchema>> {
+    class KoordinatsystemKode
+    class Flate
+    abstract class Geometri
+    class Koordinat
+    class Kurve
+    class Punkt
+    class Ring
+    class Bbox
+    class Område
+
+    KoordinatsystemKode -[hidden]- Flate
+    Flate -[hidden]- Geometri
+    Geometri -[hidden]- Koordinat
+    Koordinat -[hidden]- Kurve
+    Kurve -[hidden]- Punkt
+    Punkt -[hidden]- Ring
+    Ring -[hidden]- Bbox
+    Bbox -[hidden]- Område
+  }
+
+  package Matrikkel.Applikasjonsskjema.Felles <<applicationSchema>> {
+    class ByggIdent
+    class Matrikkelnummer
+
+    ByggIdent -[hidden]- Matrikkelnummer
+  }
+
+  package Plan.Applikasjonsskjema.Felles <<applicationSchema>> {
+    abstract class Administrativenhetsnummer
+    class Fylke
+    class Kommune
+    class NasjonalArealplanId
+    class Stat
+
+    Administrativenhetsnummer -[hidden]- Fylke
+    Fylke -[hidden]- Kommune
+    Kommune -[hidden]- NasjonalArealplanId
+    NasjonalArealplanId -[hidden]- Stat
+  }
+
+  Variantformat -[hidden]- KoordinatsystemKode
+  Variantformat -[hidden]- ByggIdent
+  Variantformat -[hidden]- Administrativenhetsnummer
+}
+@enduml

--- a/media/uml-pakker-som-inngaar-i-loesninger-geointegrasjon-eksempel.puml
+++ b/media/uml-pakker-som-inngaar-i-loesninger-geointegrasjon-eksempel.puml
@@ -1,0 +1,17 @@
+@startuml
+package Arkivstruktur <<applicationSchema>>
+package Kodelister <<applicationSchema>>
+package LoggingOgSporing <<applicationSchema>>
+
+package GeoIntegrasjon {
+  package Felles.Geometri <<applicationSchema>>
+  package Matrikkel.Applikasjonsskjema.Felles <<applicationSchema>>
+  package Plan.Applikasjonsskjema.Felles <<applicationSchema>>
+}
+
+Kodelister .. Arkivstruktur : <<import>>
+Arkivstruktur . LoggingOgSporing : <<import>>
+Arkivstruktur .. Felles.Geometri : <<import>>
+Arkivstruktur .. Matrikkel.Applikasjonsskjema.Felles : <<import>>
+Arkivstruktur .. Plan.Applikasjonsskjema.Felles : <<import>>
+@enduml

--- a/media/uml-pakker-som-inngaar-i-loesninger-noark5-kjerne.puml
+++ b/media/uml-pakker-som-inngaar-i-loesninger-noark5-kjerne.puml
@@ -1,0 +1,23 @@
+@startuml
+package Admin <<applicationSchema>>
+package Kodelister <<applicationSchema>>
+package Arkivstruktur <<applicationSchema>>
+package LoggingOgSporing <<applicationSchema>>
+package Sakarkiv <<applicationSchema>>
+
+package GeoIntegrasjon {
+  package Felles.Geometri <<applicationSchema>>
+  package Matrikkel.Applikasjonsskjema.Felles <<applicationSchema>>
+  package Plan.Applikasjonsskjema.Felles <<applicationSchema>>
+}
+
+Admin .> Kodelister : <<import>>
+Sakarkiv ..> Kodelister : <<import>>
+Sakarkiv .> Arkivstruktur : <<import>>
+LoggingOgSporing ..> Kodelister : <<import>>
+Kodelister <.. Arkivstruktur : <<import>>
+Arkivstruktur .> LoggingOgSporing : <<import>>
+Arkivstruktur ..> Felles.Geometri : <<import>>
+Arkivstruktur ..> Matrikkel.Applikasjonsskjema.Felles : <<import>>
+Arkivstruktur ..> Plan.Applikasjonsskjema.Felles : <<import>>
+@enduml

--- a/media/uml-pakker-som-inngaar-i-loesninger-sakarkiv-eksempel.puml
+++ b/media/uml-pakker-som-inngaar-i-loesninger-sakarkiv-eksempel.puml
@@ -1,0 +1,8 @@
+@startuml
+package Sakarkiv <<applicationSchema>>
+package Arkivstruktur <<applicationSchema>>
+package Kodelister <<applicationSchema>>
+
+Sakarkiv .. Arkivstruktur : <<import>>
+Sakarkiv .. Kodelister : <<import>>
+@enduml

--- a/media/uml-sakarkiv-entiteter-forenklet.puml
+++ b/media/uml-sakarkiv-entiteter-forenklet.puml
@@ -1,0 +1,28 @@
+@startuml
+skinparam classAttributeIconSize 0
+class Arkivstruktur.Klasse <Arkivenhet>
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Basisregistrering <Registrering>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+class Sakarkiv.Saksmappe <Mappe> #pink
+class Sakarkiv.Presedens #pink
+class Sakarkiv.Journalpost <Basisregistrering> #pink
+class Sakarkiv.Avskrivning #pink
+class Sakarkiv.Dokumentflyt #pink
+
+Arkivstruktur.Klasse o--> "+underklasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Klasse "+klasse 0..1" o-> "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
+Sakarkiv.Saksmappe o--> "+sekundærklassifikasjon 0..*" Arkivstruktur.Klasse
+Sakarkiv.Presedens "+presedens 0..*" <--o "+sak 0..*" Sakarkiv.Saksmappe
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Registrering <|-- Arkivstruktur.Basisregistrering
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+Sakarkiv.Presedens "+presedens 0..*" <--o "+journalpost 0..*" Sakarkiv.Journalpost
+Sakarkiv.Journalpost "+avskrivning 0..*" *--> Sakarkiv.Avskrivning
+Sakarkiv.Journalpost "+dokumentflyt 0..*" *--> Sakarkiv.Dokumentflyt
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
+@enduml

--- a/media/uml-sakarkiv-entiteter.puml
+++ b/media/uml-sakarkiv-entiteter.puml
@@ -1,0 +1,23 @@
+@startuml uml-sakarkiv-entiteter.puml
+
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Basisregistrering <Registrering>
+class Sakarkiv.Journalpost <Basisregistrering>
+class Sakarkiv.Saksmappe <Mappe>
+
+Arkivstruktur.Registrering <|-- Arkivstruktur.Basisregistrering
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+Arkivstruktur.Mappe <|- Sakarkiv.Saksmappe
+
+Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Mappe o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Sakarkiv.Saksmappe *-> "+sakspart 0..*" Sakarkiv.Sakspart 
+Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*\n" Sakarkiv.Presedens
+Sakarkiv.Journalpost "+journalpost 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
+
+Sakarkiv.Journalpost *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
+Sakarkiv.Journalpost *--> "+dokumentflyt 0..*\n" Sakarkiv.Dokumentflyt
+Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse 
+@enduml

--- a/media/uml-saksmappe.puml
+++ b/media/uml-saksmappe.puml
@@ -1,0 +1,14 @@
+@startuml
+skinparam classAttributeIconSize 0
+
+!include media/uml-class-saksmappe-all.iuml
+!include media/uml-class-presedens.iuml
+!include media/uml-class-sakspart.iuml
+
+class Arkivstruktur.Klasse <Arkivenhet>
+Arkivstruktur.Klasse "\n\n+sekundærklassifikasjon 0..*"  <--o Sakarkiv.Saksmappe
+Arkivstruktur.Klasse o--> "\n+underklasse 0..*" Arkivstruktur.Klasse
+Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
+Sakarkiv.Saksmappe *--> "+sakspart 0..*" Sakarkiv.Sakspart
+
+@enduml

--- a/media/uml-simple-datatyper-eller-primitiver.puml
+++ b/media/uml-simple-datatyper-eller-primitiver.puml
@@ -1,0 +1,6 @@
+@startuml
+'FIXME dropped caption "class Fig08_SimpleType"
+class BasicTypes.string << simple >>
+class Metadata.SystemID << simple >>
+BasicTypes.string <|--  Metadata.SystemID
+@enduml


### PR DESCRIPTION
This allow us to track changes in the UML diagrams using git,
and thanks to the use of include files, consistent class
definitions across UML diagrams.

This further make it possible to generate the UML diagram
images automatically from the source files using a command
line free software tool, avoiding the need to accept a non
free software license to be able to correct the UML diagrams.

Fixes #76