### PR TITLE
Use only entities from this specification in UML notation example.

### DIFF
--- a/kapitler/media/uml-forklaring-om-notasjon-som-er-brukt.puml
+++ b/kapitler/media/uml-forklaring-om-notasjon-som-er-brukt.puml
@@ -3,56 +3,30 @@ skinparam classAttributeIconSize 0
 skinparam nodesep 180
 
 'FIXME dropped caption "class Klassediagram_forklaring"
-class Albumenhet {
-  +systemID : SystemID
-  +oppdatertDato : datetime
-  +opprettetDato : datetime [0..1]
-  +opprettetAv : string [0..1]
-  +oppdatertAv : string
-  +referanseOpprettetAv : SystemID [0..1]
-}
-class Foto {
-  +systemID : SystemID
-  +versjonsnummer : integer
-  +format : Format
-  +opprettetDato : datetime [0..1]
-  +opprettetAv : string [0..1]
-  +filstoerrelse : integer
-  -- constraints --
-  {Det skal finnesvære mulig å |formattesting}
-  {M001 systemID: Skal ikke kunne endres}
-  -- notes --
-  Her kan de lages en forklaring om hva
-  denne klassen skal brukes til
-}
-Albumenhet "0..*" *-> "+foto 1..*" Foto
-class Fil {
-  +filnavn : string
-  +mimeType : string
-}
-Foto --> "+fotofil 0..1" Fil
-note bottom of Fil : Dette er eksempel på en\nnote, som kan være\nknytta til en klasse (som\ndenne) eller kan være\n"løs"
 
-class Fotoalbum {
-  +tittel : string
-  +beskrivelse : string [0..1]
-  +oppbevaringssted : string [0..*]
-}
-class Albumdel {
-  +tittel : string
-  +beskrivelse : string [0..1]
-  +oppbevaringssted : string [0..*]
-  +gradering : Gradering [0..1]
-}
-Fotoalbum "+underalbum 0..*" --o Fotoalbum
-Fotoalbum "+album 1" o- "+albumdel 0..*" Albumdel
-Albumenhet <|-- Fotoalbum
-Albumenhet <|-- Albumdel
-
-!include kapitler/media/uml-datatype-gradering.iuml
+!include kapitler/media/uml-class-arkivenhet.iuml
+!include kapitler/media/uml-class-avskrivning.iuml
+!include kapitler/media/uml-class-basisregistrering.iuml
+!include kapitler/media/uml-class-journalpost.iuml
+!include kapitler/media/uml-class-mappe.iuml
+!include kapitler/media/uml-class-registrering.iuml
 !include kapitler/media/uml-codelist-graderingskode.iuml
+!include kapitler/media/uml-datatype-gradering.iuml
 
-'FIXME figure out if two SystemID classes can co-exist
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Mappe
+Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Registrering
+Arkivstruktur.Registrering <|-- Arkivstruktur.Basisregistrering
+Arkivstruktur.Basisregistrering <|-- Sakarkiv.Journalpost
+
+Arkivstruktur.Arkivenhet --[hidden] Arkivstruktur.SystemID
+
+Arkivstruktur.Mappe o-- "undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Mappe "mappe 0..1" o--> "registrering 0..*" Arkivstruktur.Registrering
+Sakarkiv.Journalpost -* "avskrivning 0..*" Sakarkiv.Avskrivning
+package Arkivstruktur {
+note left of Arkivstruktur.Basisregistrering : Dette er eksempel på en\nnote, som kan være\nknytta til en klasse (som\ndenne) eller kan være\n"løs"
+}
+
 class Arkivstruktur.SystemID <<simple>> {
   -- notes --
   Definisjon: Entydig
@@ -63,7 +37,6 @@ class BasicTypes.string <<simple>>
 class Arkivstruktur.SystemID <<simple>>
 BasicTypes.string <|-- Arkivstruktur.SystemID
 'layout adjustments
-Fotoalbum <-[hidden]- Arkivstruktur.Gradering
-Arkivstruktur.Gradering <-[hidden]- Kodelister.Graderingskode
-Albumdel <-[hidden]- BasicTypes.string
+Arkivstruktur.Gradering <-[hidden] Arkivstruktur.Registrering
+Kodelister.Graderingskode <-[hidden] Arkivstruktur.Gradering
 @enduml


### PR DESCRIPTION
The original UML notation example introduce entities that are not part of
this specification, like Foto, Fil, Albumdel etc.  This is confusing for
the reader when trying to figure out what these classes have to to with
this specification.  It is better to show the notation used using entities
that are part of this specification.  Rewrote the UML diagram to use
Arkivenhet, Mappe, Registrering, Journalpost, Avskrivning and related
code lists and relations.