### PR TITLE
La Kryssreferanse arve fra Arkivenhet.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -978,7 +978,7 @@ Table: Restriksjoner
 
 *Type:* ***Class***
 
-*Arver:* 
+*Arver:* ***Arkivenhet***
 
 Dette er en referanse på tvers av hierarkiet i arkivstrukturen.
 Referansen kan gå fra en mappe til en annen mappe, fra en registrering
@@ -992,6 +992,10 @@ kan kun være en referanse til en arkivenhet. I og med at
 kryssreferanser knyttes til Mappe og Basisregistrering, vil det si at
 Referanser også knyttes til alle utvidelsene (spesialiseringer) under
 disse (Saksmappe, Moetemappe og Journalpost, Moeteregistrering).
+
+Ved avlevering i tråd med XML-skjema for Noark 5 versjon 4 så droppes
+samtlige felt arvet fra Arkivenhet, da disse ikke har korresponderende
+felt i dette avleveringsformatet.
 
 Table: Relasjoner
 

--- a/kapitler/media/uml-class-kryssreferanse.iuml
+++ b/kapitler/media/uml-class-kryssreferanse.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Arkivstruktur.Kryssreferanse {
+class Arkivstruktur.Kryssreferanse <Arkivenhet> {
   +referanseTilMappe : SystemID [0..1]
   +referanseTilKlasse : SystemID [0..1]
   +referanseTilRegistrering : SystemID [0..1]


### PR DESCRIPTION
Dette sikrer at den får en SystemID-verdi som kan brukes i "self"-URLer,
og sikrer at det tas vare på hvem som opprettet og endret en
kryssreferanse, samt når det ble gjort.

Fixes #151