### PR TITLE
Korriger relasjonsnøkkellisten for Mappe

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -1082,12 +1082,10 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/kryssreferanse/           |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/arkivdel/                 |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-kryssreferanse/        |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-arkivdel/              |
 | REST\_REL | self                                                                     |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-merknad/               |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-registrering/          |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/klasse/                   |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-klasse/                |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/registrering/             |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-nasjonalidentifikator/ |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/merknad/                  |
@@ -1097,6 +1095,9 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/metadata/mappetype/                     |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/undermappe/               |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/nasjonaleidentifikator/   |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-basisregistrering/     |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-journalpost/           |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-moeteregistrering/     |
 
 Table: Attributter
 


### PR DESCRIPTION
Fjerner ny-arkivdel og ny-klasse, samt legger til ny-basisregistrering,
ny-journalpost og ny-moeteregistrering, for å reflektere bedre hvilke
operasjoner som kan gjøres på en mappe.

Fixes #140