### PR TITLE
Fjern setning som forbyr støtte for søk i enkelte databaseoppføringer

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -73,9 +73,8 @@ underlagt arkivbegrensning) - inn i saksomslaget uten at dette ble
 registrert i journalen. Tilsvarende funksjonalitet bør også være mulig
 i et elektronisk arkivsystem. Her må dokumentene nødvendigvis bli
 registrert, men dette skal skje på en automatisk måte og med minst
-mulig metadata. Denne typen dokumenter skal ikke kunne søkes fram
-etter innhold, og de skal heller ikke inngå i den ordinære
-identifikasjonen (nummereringen) av journalposter. Disse dokumentene
+mulig metadata.  Denne typen dokumenter tildeles ikke identifikasjonen
+(nummereringen) i motsetning til journalposter.  Disse dokumentene
 vil heller ikke komme på offentlig journal. Men de skal kunne inngå i
 arkivuttrekk dersom de er bevaringsverdige, og det må være mulig å
 skjerme dem internt. I Noark-4 ble dette kalt "loggede dokumenter". I


### PR DESCRIPTION
Fjerner setning som sier det ikke skal være mulig å søke på innhold i
instanser av Registrering, slik at disse kan behandles som alle andre
entiteter i API-et.

Fixes #79