### PR TITLE
Endre DNummer til dNummer for å gjøre API-et mer konsistent

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -2901,7 +2901,7 @@ Table: Attributter
 | **Navn**               | **Merknad** | **Multipl.** | **Kode** | **Type**           |
 | ---------------------- | ----------- | ------------ | -------- | ------------------ |
 | foedselsnummer         |             | \[0..1\]     |          | string             |
-| DNummer                |             | \[0..1\]     |          | string             |
+| dNummer                |             | \[0..1\]     |          | string             |
 | navn                   |             | \[1..1\]     |          | string             |
 | postadresse            |             | \[0..1\]     |          | EnkelAdresse       |
 | bostedsadresse         |             | \[0..1\]     |          | EnkelAdresse       |
@@ -3165,7 +3165,7 @@ Table: Attributter
 | **Navn**               | **Merknad** | **Multipl.** | **Kode** | **Type**           |
 | ---------------------- | ----------- | ------------ | -------- | ------------------ |
 | foedselsnummer         |             | \[0..1\]     |          | string             |
-| DNummer                |             | \[0..1\]     |          | string             |
+| dNummer                |             | \[0..1\]     |          | string             |
 | navn                   |             | \[1..1\]     |          | string             |
 | postadresse            |             | \[0..1\]     |          | EnkelAdresse       |
 | bostedsadresse         |             | \[0..1\]     |          | EnkelAdresse       |

--- a/kapitler/media/uml-class-korrespondansepartperson.iuml
+++ b/kapitler/media/uml-class-korrespondansepartperson.iuml
@@ -1,7 +1,7 @@
 @startuml
 class Sakarkiv.KorrespondansepartPerson <Korrespondansepart> {
   +foedselsnummer : string [0..1]
-  +DNummer : string [0..1]
+  +dNummer : string [0..1]
   +navn : string
   +postadresse : EnkelAdresse [0..1]
   +bostedsadresse : EnkelAdresse [0..1]

--- a/kapitler/media/uml-class-sakspartperson.iuml
+++ b/kapitler/media/uml-class-sakspartperson.iuml
@@ -1,7 +1,7 @@
 @startuml
 class Sakarkiv.SakspartPerson <Sakspart> {
   +foedselsnummer : string [0..1]
-  +DNummer : string [0..1]
+  +dNummer : string [0..1]
   +navn : string
   +postadresse : EnkelAdresse [0..1]
   +bostedsadresse : EnkelAdresse [0..1]


### PR DESCRIPTION
Felt for å ta vare på D-nummer har to varianter i teksten, DNummer
og dNummer.  Endrer alle til dNummer slik at API-brukere slipper å
forholde seg til to ulike navn for samme felttype.

Fixes #87