### PR TITLE
Legg inn forloeper/arvtaker i Arkivdel som relasjoner

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -916,6 +916,14 @@ Mer generelt kan klienter benytte href for rel="self" for aktuelle
 objekter sammen med $ref parameter for å slette, endre eller opprette
 referanser mellom objekter.
 
+Når en oppdaterer en toveis relasjon mellom to instanser med
+relasjonsnavn på begge sider, så blir relasjonen også synlig på den
+andre siden av relasjonen.  For eksempel hvis en legger inn en lenke
+fra en Arkivdel A til forrige Arkivdel B ved hjelp av
+«forrigearkivdel»-relasjonsnøkkelen, så blir det automatisk en lenke
+til neste Arkivdel A i Arkivdel B synlig med
+«nestearkivdel»-relasjonsnøkkel.
+
 **For å opprette ny referanse**
 
 Her opprettes ny referanse mellom registrering og dokumentbeskrivelse.

--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -310,6 +310,7 @@ Table: Relasjoner
 | ----------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
 | **Generalization** (Source → Destination) | Arkivdel                                                 | Arkivenhet             |             |
 | **Aggregation** (Bi-Directional)           | arkivdel 0..* Arkivdel                                   | arkiv 1 Arkiv          |             |
+| **Aggregation** (Bi-Directional)           | forrigearkivdel 0..1 Arkivdel                           | nestearkivdel 0..1 Arkivdel | SystemID for forrige/neste Arkivdel avleveres som referanseForloeper(M202)/referanseArvtaker(M203). |
 | **Aggregation** (Bi-Directional)           | klassifikasjonssystem 0..1 Klassifikasjonssystem         | arkivdel 1..* Arkivdel |             |
 | **Aggregation** (Bi-Directional)           | registrering 0..* Registrering                           | arkivdel 0..1 Arkivdel |             |
 | **Aggregation** (Bi-Directional)           | mappe 0..* Mappe                                         | arkivdel 0..1 Arkivdel |             |
@@ -329,6 +330,8 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/klassifikasjonssystem/    |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/arkiv/                    |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/mappe/                    |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/forrigearkivdel/   |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/nestearkivdel/     |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/metadata/dokumentmedium/                |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/metadata/arkivdelstatus/                |
 | REST\_REL | self                                                                     |

--- a/kapitler/media/uml-arkivstruktur-arkiv-og-arkivdel.puml
+++ b/kapitler/media/uml-arkivstruktur-arkiv-og-arkivdel.puml
@@ -85,6 +85,7 @@ Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" <-o "+arkivdel
 Arkivstruktur.Klassifikasjonssystem "+sekundaerklassifikasjonssystem 0..*" <-o Arkivstruktur.Arkivdel
 Arkivstruktur.Arkivdel "+arkivdel 0..1" o-> "+mappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Mappe "+overmappe 0..1" o--> "+undermappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 
 Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.Sletting
 Arkivstruktur.Arkivdel <-[hidden]- Arkivstruktur.Kassasjon

--- a/kapitler/media/uml-arkivstruktur-arkivenhet-som-basis-klasse.puml
+++ b/kapitler/media/uml-arkivstruktur-arkivenhet-som-basis-klasse.puml
@@ -29,6 +29,7 @@ Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Klasse
 Arkivstruktur.Klasse "+overklasse 0..1" o--> "+underklasse 0..*" Arkivstruktur.Klasse
 Arkivstruktur.Arkivenhet <|-- Arkivstruktur.Mappe
 Arkivstruktur.Arkivdel "\n+arkivdel 0..1" o-- "+mappe 0..*" Arkivstruktur.Mappe
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 Arkivstruktur.Klasse "+klasse 0..1" o-- "+mappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Mappe "+overmappe 0..1" o--> "+undermappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe

--- a/kapitler/media/uml-arkivstruktur-attributter.puml
+++ b/kapitler/media/uml-arkivstruktur-attributter.puml
@@ -23,6 +23,7 @@ Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" <--o "+arkivde
 Arkivstruktur.Klassifikasjonssystem "+sekundaerklassifikasjonssystem 0..*" <--o Arkivstruktur.Arkivdel
 
 Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o--> "+klasse 0..*" Arkivstruktur.Klasse
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
 Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe

--- a/kapitler/media/uml-arkivstruktur-forenklet-modell.puml
+++ b/kapitler/media/uml-arkivstruktur-forenklet-modell.puml
@@ -6,6 +6,7 @@ class Arkivstruktur.Registrering <Arkivenhet>
 class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
 class Arkivstruktur.Dokumentobjekt
 Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering  0..*" Arkivstruktur.Registrering
 Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse
 Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt 0..*" Arkivstruktur.Dokumentobjekt

--- a/kapitler/media/uml-arkivstruktur-forklart-som-hovedmodell.puml
+++ b/kapitler/media/uml-arkivstruktur-forklart-som-hovedmodell.puml
@@ -21,6 +21,7 @@ Arkivstruktur.Klasse "+klasse 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
 Arkivstruktur.Mappe "+overmappe 0..1" o--> "+undermappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Klasse "+klasse 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+registrering  0..*\n" Arkivstruktur.Registrering
 Arkivstruktur.Arkivdel "\n+arkivdel 0..1" o--> "+mappe  0..*" Arkivstruktur.Mappe
 Arkivstruktur.Registrering "+registrering 1..*" o--> "+dokumentbeskrivelse 0..*" Arkivstruktur.Dokumentbeskrivelse

--- a/kapitler/media/uml-arkivstruktur-omfattende-forklart.puml
+++ b/kapitler/media/uml-arkivstruktur-omfattende-forklart.puml
@@ -50,6 +50,7 @@ Arkivstruktur.Klasse "+overklasse 0..1" o-> "+underklasse 0..*" Arkivstruktur.Kl
 Arkivstruktur.Klasse "+klasse 0..1" <-> "+kryssreferanse 0..*" Arkivstruktur.Kryssreferanse
 Arkivstruktur.Mappe "+mappe 0..1" <-> "+kryssreferanse 0..*" Arkivstruktur.Kryssreferanse
 Arkivstruktur.Kryssreferanse "+kryssreferanse 0..*" <--> "+registrering 0..1" Arkivstruktur.Basisregistrering
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 Arkivstruktur.Arkivdel "+arkivdel 0..1" o--> "+mappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Klasse "+sekundaerklassifikasjon 0..*" <--o Sakarkiv.Saksmappe
 Arkivstruktur.Klasse "+klasse 0..*" o--> "+mappe 0..*" Arkivstruktur.Mappe

--- a/kapitler/media/uml-hovedmodell-saksbehandling.puml
+++ b/kapitler/media/uml-hovedmodell-saksbehandling.puml
@@ -17,6 +17,7 @@ class Sakarkiv.Dokumentflyt #pink
 
 Arkivstruktur.Arkiv "+overarkiv 0..1" o-> "+underarkiv 0..*" Arkivstruktur.Arkiv
 Arkivstruktur.Arkiv "+arkiv 1" o--> "+arkivdel 0..*" Arkivstruktur.Arkivdel
+Arkivstruktur.Arkivdel "nestearkivdel 0..1" o--> "forrigearkivdel 0..1" Arkivstruktur.Arkivdel
 Arkivstruktur.Arkivdel "+arkivdel 1..*" o--> "+klassifikasjonssystem 0..1" Arkivstruktur.Klassifikasjonssystem
 Arkivstruktur.Arkivdel o--> "+sekundaerklassifikasjonssystem 0..*" Arkivstruktur.Klassifikasjonssystem
 Arkivstruktur.Klassifikasjonssystem "+klassifikasjonssystem 0..1" o--> "+klasse 0..*" Arkivstruktur.Klasse


### PR DESCRIPTION
Endringen gjør det klart at slike relasjoner må peke til eksisterende
instanser i arkivet og at oppdatering av slike relasjoner gjøres på
begge sider samtidig.

Merk, antagelig bør attributtene referanseForloeper og referanseArvtaker
fjernes for å unngå duplisering av informasjon i relasjon og attributt,
jamfør diskusjon i endringsforslag #162.

Fixes #101