### PR TITLE
Tall i JSON skal alltid overføres som JSON-nummer

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -1237,6 +1237,9 @@ informasjonsmodellen skal valideres av kjernen. For eksempel hvis en
 mappe er avsluttet så skal det ikke være mulig å registrere flere
 registreringer på denne (jfr krav 5.4.7).
 
+Merk at tallfelt som overføres som JSON alltid skal overføres
+formatert som et JSON Number, dvs. uten anførselstegn.
+
 ## Håndtering av API-feil
 
 API-et returnerer to nivåer av tilbakemeldinger ved feil:


### PR DESCRIPTION
Det betyr at hverken klient eller tjener skal akseptere at de
overføres som strenger som så tolkes som tall i 10-tallsystemet.

Fixes #83