### PR TITLE
Endre relasjonsnøkkel tilknyttet Tilgang til ...tilgang/.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -3324,11 +3324,11 @@ Table: Relasjonsnøkler
 
 | **Tag**   | **Verdi**                                                      |
 | --------- | -------------------------------------------------------------- |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/admin/ny-rettighet/           |
 | REST\_REL | self                                                           |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/admin/tilgang/                |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/admin/ny-tilgang/             |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/metadata/tilgangsrestriksjon/ |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/metadata/tilgangskategori/    |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/admin/rettighet/              |
 
 Table: Attributter
 


### PR DESCRIPTION
Entiteten trenger en relasjonsnøkkel, og relasjonsnøkkelen
"admin/rettighet/" er en skrivefeil for "admin/tilgang/".
Tilsvarende for "admin/ny-tilgang/".

Fixes #180