### PR TITLE
Klargjør oppretting av entiteter som arver fra Mappe og Registrering

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -732,9 +732,11 @@ Table: Resultatkoder ved oppdatering av objekt
 
 #### Utvid objekter til andre typer
 
-Noen objekter kan utvides fra sin basistype til en annen subtype. Dette
-gjelder for eksempel Mappe og Saksmappe. Dette annonseres ved hjelp av
-**utvid-til-xx** metodene.
+Hvis en ikke ønsker å opprette en instans med riktig entitet direkte
+ved å bruke **ny-xx**-metodene, men ønsker å utvide en entitet fra en
+basisentitet til en underentitet uten å endre systemID, så kan en
+bruke **utvid-til-xx*-metodene.  Dette gjelder for eksempel Mappe og
+Saksmappe.
 
 Ved uthenting av en mappe vil du få følgende relasjon tilbake:
 
@@ -796,7 +798,7 @@ Resultatkoder ved utvidelse av objekt
 | ---------- | --------------------------------------------- |
 | 200        | OK					     |
 | 400	     | BadRequest - ugyldig forespørsel		     |
- 
+
 Resultatkode 400 leveres dersom id til eksterende mappe er ugyldig eller
 det mangler påkrevde felter.
 

--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -332,6 +332,21 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/metadata/arkivdelstatus/                |
 | REST\_REL | self                                                                     |
 
+Hvis pakken Sakarkiv er tilgjengelig, så skal følgende relasjonsnøkkel
+også være tilgjengelig via Arkivdel-instanser.
+
+Table: Relasjonsnøkler
+
+| **Tag**   | **Verdi**                                                                |
+| --------- | ------------------------------------------------------------------------ |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-saksmappe/          |
+
+Merk at underliggende lister med Saksmappe og andre underentiteter er
+tilgjengelig via relasjonsnøkkel
+`https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/mappe/`,
+dermed er det ikke egne relasjonsnøkler for å hente ut lister med de
+spesifikke under-entitetene.
+
 Table: Attributter
 
 | **Navn**              | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
@@ -523,6 +538,16 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-merknad/           |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/basisregistrering/    |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/kryssreferanse/       |
+
+Hvis pakken Sakarkiv er tilgjengelig, så skal følgende relasjonsnøkler
+også være tilgjengelig via Basisregistrering-instanser som har en
+Saksmappe som foreldre.
+
+Table: Relasjonsnøkler
+
+| **Tag**   | **Verdi**                                                                |
+| --------- | ------------------------------------------------------------------------ |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/utvid-til-journalpost/ |
 
 Table: Attributter
 
@@ -891,6 +916,15 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-registrering/          |
 | REST\_REL | self                                                                     |
 
+Hvis pakken Sakarkiv er tilgjengelig, så skal følgende relasjonsnøkler
+også være tilgjengelig via Klasse-instanser.
+
+Table: Relasjonsnøkler
+
+| **Tag**   | **Verdi**                                                                |
+| --------- | ------------------------------------------------------------------------ |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-saksmappe/          |
+
 Table: Attributter
 
 | **Navn**              | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
@@ -1153,6 +1187,16 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-journalpost/           |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-moeteregistrering/     |
 
+Hvis pakken Sakarkiv er tilgjengelig, så skal følgende relasjonsnøkler
+også være tilgjengelig via Mappe-instanser.
+
+Table: Relasjonsnøkler
+
+| **Tag**   | **Verdi**                                                                |
+| --------- | ------------------------------------------------------------------------ |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-saksmappe/          |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/utvid-til-saksmappe/   |
+
 Table: Attributter
 
 | **Navn**  | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
@@ -1277,16 +1321,23 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/mappe/                    |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-dokumentbeskrivelse/   |
 | REST\_REL | self                                                                     |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-klasse/                |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/dokumentbeskrivelse/      |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/arkivdel/                 |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-mappe/                 |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/klasse/                   |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/nasjonaleidentifikator/   |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-arkivdel/              |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-registrering/          |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-nasjonalidentifikator/ |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/registrering/             |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/utvid-til-basisregistrering/   |
+
+Hvis pakken Sakarkiv er tilgjengelig, så skal følgende relasjonsnøkler
+også være tilgjengelig via Registrering-instanser som har en Saksmappe
+som foreldre.
+
+Table: Relasjonsnøkler
+
+| **Tag**   | **Verdi**                                                                |
+| --------- | ------------------------------------------------------------------------ |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/utvid-til-journalpost/ |
 
 Table: Attributter
 
@@ -2858,7 +2909,6 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-avskrivning/        |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/presedens/             |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-presedens/          |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-journalpost/        |
 | REST\_REL | self                                                             |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/journalpost/           |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-dokumentflyt/       |
@@ -3178,7 +3228,7 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-sakspart/             |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-presedens/            |
 | REST\_REL | self                                                               |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-saksmappe/            |
+| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/sakarkiv/ny-journalpost/          |
 
 Table: Attributter
 


### PR DESCRIPTION
Legg til manglende relasjonsnøkler for å opprette underentitetene
Saksmappe under Arkivdel, Klasse og Mappe.  Noen av dem skal kun være
synlige hvis pakken Sakarkiv tilgjengelig.  Journalpost kan kun opprettes
under Saksmappe.

Har ikke korrigert bruk og utviding av Møterelaterte klasser, i tråd med
det som er sagt i mangelmelding #96 om at Moete-pakken skal fjernes fra
API-spesifikasjonen.

Fjerner uønskede relasjonsnøkler fra Registrering, det skal ikke være
mulig å opprette ny Klasse, Mappe, Arkivdel eller Registrering via en
Registrering.

Fjern feil relasjonsnøkkel fra Journalpost for oppretting av
underliggende Journalpost.

Fjern feil relasjonsnøkkel fra Saksmappe for oppretting av
Saksmappe.

Legg inn relasjonsnøkkel under Saksmappe for å opprette Journalpost.

Justerte omtale av utvid-til-* i kapittel 6 for å forklare hvorfor det
finnes både ny-* og utvid-til-* i API-et.

Fixes #28