### PR TITLE
Unicodes kontrolltegn anses også som usynlige tegn

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -9,17 +9,85 @@
 |![](./media/uml-assosiasjoner-brukt-med-klasser.png) | Klasser kan knyttes sammen med ***assosiasjoner***. Assosiasjoner vises som streker mellom to klasser. En assosiasjon der begge ender er knytta til samme klasse kalles ***selv-assosiasjon***. Eksempel: Mappe kan ha undermappe med samme struktur som mappa selv. Dette brukes der en trenger et hierarki av like klasser. En assosiasjon kan være ***aggregering***. Symbolet er en strek mellom to klasser med åpen diamant i ene enden. Eksempel: Ei Mappe ***har*** Registrering(er). En registrering er en selvstendig enhet, som «overlever» selv om Mappa blir sletta. |
 |![](./media/uml-generalisering-brukt-med-klasser.png) | Assosiasjoner kan være ***generalisering/spesialisering***. Symbolet er en strek med en trekant i ene enden. Eksempel er Basisregistrering som er en generalisering av Journalpost og Moeteregistrering. En kan også si at Journalpost er en spesialisering av basisregistrering. I Basisregistrering legges alle felles-kjennetegnene. Felleskjennetegnene arves så ned på Journalpost og Moeteregistrering. Dette leses som Journalpost ***er en*** Basisregistrering. Dersom en klasse er en spesialisering av en annen klasse som ikke er tatt med i diagrammet, skrives ofte navnet på den generaliserte klassen i øvre høyre hjørne av klasse-firkanten. I eksempelet kan vi derfor se at Basisregistrering er en spesialisering av Registrering, selv om klassen Registrering ikke finnes i diagrammet. |
 |![](./media/uml-komposisjon-brukt-med-klasser.png) | En assosiasjon kan også være ***komposisjon***. Symbolet er en strek mellom to klasser med lukka diamant i den ene enden. En Basisregistrering ***har*** Korrespondansepart(er). En Korrespondansepart kan ikke eksistere uten at den er knytta til en mappe. Slettes («dør») basisregistreringen vil også korrespondanseparten bli sletta («vil dø»). Assosiasjonene forteller også hvilken vei de er ***navigerbare***. Symbolet for dette er piler i endene på streken. Eksempel: En basisregistrering «vet» hvilke korrespondansepart(er) som tilhører basisregistreringen, mens korrespondanseparten ikke vet hvilken basisregistrering den tilhører.|
-|![](./media/uml-multiplisitet-brukt-med-klasser.png) | ***Multiplisiteten*** forteller hvor mange forekomster som kan inngå. Multiplisitet kan brukes i forbindelse med assosiasjoner og også på klasseattributter. Dette vises med minst ett tall, men ofte to tall med to prikker mellom (0..1). Det første tallet angir minimums-multiplisitet (så mange det minst må være), det andre tallet er maksimumsmultiplisitet (så mange det maksimalt kan være). Eksempel: En Mappe kan høre til ingen eller en (0..1) Klasse, mens en Klasse kan «ha» ingen eller flere (0..***) Mapper(er). Stjernesymbol brukes til å angi «mange» (ubestemt tall større enn 1).En klasseattributt har angitt multiplisitet med klammeparenteser (\[0..1\]). Klasseattributten noekkelord kan forekomme ingen eller en gang. Når det ikke er angitt multiplisitet, skal dette oftest tolkes som (1..1). En Klasse skal alltid ha en klasseID, og kan bare ha en. En tom tekststreng-verdi ("") og en tekststreng som kun inneholder usynlige tegn (definert som Unicode-tegn i kategorien «Space Separator», se tabell) er likestilt med en manglende verdi, slik at ved multiplisiteten [1..1] betyr det at klasseID også må ha en verdi forskjellig fra tom streng.|
+|![](./media/uml-multiplisitet-brukt-med-klasser.png) | ***Multiplisiteten*** forteller hvor mange forekomster som kan inngå. Multiplisitet kan brukes i forbindelse med assosiasjoner og også på klasseattributter. Dette vises med minst ett tall, men ofte to tall med to prikker mellom (0..1). Det første tallet angir minimums-multiplisitet (så mange det minst må være), det andre tallet er maksimumsmultiplisitet (så mange det maksimalt kan være). Eksempel: En Mappe kan høre til ingen eller en (0..1) Klasse, mens en Klasse kan «ha» ingen eller flere (0..***) Mapper(er). Stjernesymbol brukes til å angi «mange» (ubestemt tall større enn 1).En klasseattributt har angitt multiplisitet med klammeparenteser (\[0..1\]). Klasseattributten noekkelord kan forekomme ingen eller en gang. Når det ikke er angitt multiplisitet, skal dette oftest tolkes som (1..1). En Klasse skal alltid ha en klasseID, og kan bare ha en. En tom tekststreng-verdi ("") og en tekststreng som kun inneholder usynlige tegn (definert som beskrevet i egen tabell over usynlige tegn) er likestilt med en manglende verdi, slik at ved multiplisiteten [1..1] betyr det at klasseID også må ha en verdi forskjellig fra tom streng.|
 |![](./media/uml-simple-datatyper-eller-primitiver.png) | Datatypene kan også være ***simple datatyper*** eller ***primitiver***. Disse brukes for å gi mulighet for restriksjoner også på primitivene. Epostadresse kan være modellert som en slik primitiv. Epost er en tekst-streng, men som i tillegg til å være tekst-streng også må oppfylle visse regler knytta til det å være gyldig epostadresse (bl.a. inneholde en og bare en forekomst av tegnet @). I eksempelet i figuren er SystemID en tekststreng (string) som i tillegg må oppfylle tilleggskrav. I store modeller kan det være hensiktsmessig å plassere ulike modell-elementer i ulike pakker. Da kan det også bli lettere for leseren å forstå modellen når han får vite hvilken pakke de ulike klassene er plassert i. Modellpakker kalles ofte ***navnerom*** (namespace) Dette kan angis foran klassenavnet, skilt fra klassenavnet med kolon (:). I eksempelet hører klassen SystemID til pakken/navnerommet Metadata og klassen string tilhører pakken/navnerommet BasicTypes.|
 
 I denne versjonen av tjenestegrensesnitt-spesifikasjonen anses
-følgende tegn hentet fra Unicode som mellomromstegn.  Fremtidige
-versjoner av spesifikasjonen vil oppdatere listen med tegn hvis
-Unicode legger til flere tegn i kategorien «Space Separator».
+følgende tegn hentet fra Unicode i kategoriene «Space Separator» og
+«Control» som usynlige tegn.  Fremtidige versjoner av spesifikasjonen
+vil oppdatere listen med tegn hvis Unicode legger til flere tegn i
+disse kategoriene.
+
+Table: Usynlige tegn
 
 | Unicode-verdi | Navn                                 |
 |---------------|--------------------------------------|
+| U+0000        | Null (NUL)                           |
+| U+0001        | Start of Heading (SOH)               |
+| U+0002        | Start of Text (STX)                  |
+| U+0003        | End of Text (ETX)                    |
+| U+0004        | End of Transmission (EOT)            |
+| U+0005        | Enquiry (ENQ)                        |
+| U+0006        | Acknowledge (ACK)                    |
+| U+0007        | Alert (BEL)                          |
+| U+0008        | Backspace (BS)                       |
+| U+0009        | Character Tabulation (HT, TAB)       |
+| U+000A        | End of Line (EOL, LF, NL)            |
+| U+000B        | Line Tabulation (VT)                 |
+| U+000C        | Form Feed (FF)                       |
+| U+000D        | Carriage Return (CR)                 |
+| U+000E        | Locking-Shift One (SO)               |
+| U+000F        | Locking-Shift Zero (SI)              |
+| U+0010        | Data Link Escape (DLE)               |
+| U+0011        | Device Control One (DC1)             |
+| U+0012        | Device Control Two (DC2)             |
+| U+0013        | Device Control Three (DC3)           |
+| U+0014        | Device Control Four (DC4)            |
+| U+0015        | Negative Acknowledge (NAK)           |
+| U+0016        | Synchronous Idle (SYN)               |
+| U+0017        | End of Transmission Block (ETB)      |
+| U+0018        | Cancel (CAN)                         |
+| U+0019        | End of Medium (EOM)                  |
+| U+001A        | Substitute (SUB)                     |
+| U+001B        | Escape (ESC)                         |
+| U+001C        | File Separator (FS)                  |
+| U+001D        | Group Separator (GS)                 |
+| U+001E        | Information Separator Two (RS)       |
+| U+001F        | Information Separator One (US)       |
 | U+0020        | Space (SP)                           |
+| U+007F        | Delete (DEL)                         |
+| U+0080        | Padding Character (PAD)              |
+| U+0081        | High Octet Preset (HOP)              |
+| U+0082        | Break Permitted Here (BPH)           |
+| U+0083        | No Break Here (NBH)                  |
+| U+0084        | Index (IND)                          |
+| U+0085        | Next Line (NEL)                      |
+| U+0086        | Start of Selected Area (SSA)         |
+| U+0087        | End of Selected Area (ESA)           |
+| U+0088        | Character Tabulation Set (HTS)       |
+| U+0089        | Character Tabulation with Justification (HTJ) |
+| U+008A        | Line Tabulation Set (VTS)            |
+| U+008B        | Partial Line Down (PLD)              |
+| U+008C        | Partial Line Backward (PLU)          |
+| U+008D        | Reverse Index (RI)                   |
+| U+008E        | Single Shift Two (SS2)               |
+| U+008F        | Single Shift Three (SS3)             |
+| U+0090        | Device Control String (DCS)          |
+| U+0091        | Private Use One (PU1)                |
+| U+0092        | Private Use Two (PU2)                |
+| U+0093        | Set Transmit State (STS)             |
+| U+0094        | Cancel Character (CCH)               |
+| U+0095        | Message Waiting (MW)                 |
+| U+0096        | Start of Guarded Area (SPA)          |
+| U+0097        | End of Guarded Area (EPA)            |
+| U+0098        | Start of String (SOS)                |
+| U+0099        | Single Graphic Character Introducer (SGC) |
+| U+009A        | Single Character Introducer (SCI)    |
+| U+009B        | Control Sequence Introducer (CSI)    |
+| U+009C        | String Terminator (ST)               |
+| U+009D        | Operating System Command (OSC)       |
+| U+009E        | Privacy Message (PM)                 |
+| U+009F        | Application Program Command (APC)    |
 | U+00A0        | No-Break Space (NBSP)                |
 | U+1680        | Ogham Space Mark                     |
 | U+2000        | En Quad                              |


### PR DESCRIPTION
Legger til Unicode-kategorien «Control» til listen over tegn
som ikke kan stå alene i et tittelfelt.

Denne kommer i tillegg til endringsforslag #81 som definerte tegn i
kategorien «Space Separator» som usynlige tegn.

Fixes #39