### PR TITLE
Klargjør hvordan kodelister brukes

### DIFF
--- a/bin/text2uml
+++ b/bin/text2uml
@@ -100,7 +100,9 @@ with open('kapitler/07-tjenester_og_informasjonsmodell.md') as f:
 #            print("'", f)
 #            print(len(f))
             assert 5 == len(f)
-            if -1 == f[0].find('**Navn**') and -1 == f[0].find('--'):
+            if -1 == f[0].find('**Navn**') \
+               and -1 == f[0].find('**Kodenavn**') \
+               and -1 == f[0].find('--'):
                 if 'attributes' not in classes[heading]:
                     classes[heading]['attributes'] = OrderedDict()
                 classes[heading]['attributes'][f[0]] = {

--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -423,6 +423,16 @@ objekt i databasen, og er derfor uten «self»-relasjon.  Strukturen
 (uten "_links" og felt med verdi «null») kan brukes som utgangspunkt for en POST
 når et nytt objekt skal opprettes. 
 
+Attributter som henter verdier fra kodelister fylles inn med enten kun
+**kode**-verdien fra kodelisten eller både **kode** og **kodenavn**.
+Kodelisteverdiene kopieres fra kodelisten inn i instansen når
+attributten settes første gang eller endres, slik at fremtidige
+endringer i kodelister ikke påvirker verdier i eksisterende instanser.
+
+Kun kodelisteverdier der «inaktiv»-attributten ikke er satt til «true»
+skal brukes på nye instanser eller ved endring av kodelisteverdi på
+eksisterende instanser.
+
 Ved registrering av objektet så skal kjernen fylle ut systemID, opprettetAv og opprettetDato. OpprettetAv skal være personnavn, referanseOpprettetAv skal være en systemID. NB! Denne systemID-en kan være en entydig identifikator av brukeren i fagsystemet, slik at personen ikke nødvendigvis må være bruker i arkivkjernen. opprettetDato er datoen (eller dataTime) enheten er opprettet i fagsystemet.
 
 
@@ -430,19 +440,19 @@ Ved registrering av objektet så skal kjernen fylle ut systemID, opprettetAv og 
 {
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel": "angi tittel på mappe",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     },
     "_links": {
-        "https://rel.arkivverket.no/noark5/v4/api/administrasjon/dokumentmedium/": {
+        "https://rel.arkivverket.no/noark5/v4/api/metadata/dokumentmedium/": {
             "href": "https://n5.example.com/api/kodelister/Dokumentmedium{?$filter&$orderby&$top&$skip}",
             "templated": true
         },
-        "https://rel.arkivverket.no/noark5/v4/api/administrasjon/mappetype/": {
+        "https://rel.arkivverket.no/noark5/v4/api/metadata/mappetype/": {
             "href": "https://n5.example.com/api/kodelister/Mapetype{?$filter&$orderby&$top&$skip}",
             "templated": true
         }
@@ -463,12 +473,12 @@ Content-Type: application/vnd.noark5-v4+json
 {
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel", "Testvegen 32, ny enebolig",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     }
 }
 ```
@@ -486,12 +496,12 @@ https://n5.example.com/api/arkivstruktur/Mappe/a043d07b-9641-44ad-85d8-056730bc8
     "mappeID": "123456/2016",
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel", "Testvegen 32, ny enebolig",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     },
     "systemID": "515c45b5-e903-4320-a085-2a98813878ba",
     "opprettetDato": "2016-04-03T15:45:28.4985538+02:00",
@@ -540,19 +550,19 @@ hentes fra slik som mappetype og dokumentmedium.
 {
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel": "angi tittel på mappe",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     },
     "_links": {
-        "https://rel.arkivverket.no/noark5/v4/api/administrasjon/dokumentmedium/": {
+        "https://rel.arkivverket.no/noark5/v4/api/metadata/dokumentmedium/": {
             "href": "https://n5.example.com/api/kodelister/Dokumentmedium{?$filter&$orderby&$top&$skip}",
             "templated": true
         },
-        "https://rel.arkivverket.no/noark5/v4/api/administrasjon/mappetype/": {
+        "https://rel.arkivverket.no/noark5/v4/api/metadata/mappetype/": {
             "href": "https://n5.example.com/api/kodelister/Mapetype{?$filter&$orderby&$top&$skip}",
             "templated": true
         }
@@ -591,12 +601,12 @@ Content-Type: application/vnd.noark5-v4+json
     "mappeID": "123456/2016",
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel", "Testvegen 32, ny enebolig",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     },
     "systemID": "515c45b5-e903-4320-a085-2a98813878ba",
     "opprettetDato": "2016-04-03T15:45:28.4985538+02:00",
@@ -624,12 +634,12 @@ https://n5.example.com/api/arkivstruktur/Mappe/a043d07b-9641-44ad-85d8-056730bc8
     "mappeID": "123456/2016",
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel", "Testvegen 32, ny enebolig",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     },
     "gradering": {
         "graderingskode": {
@@ -699,12 +709,12 @@ https://n5.example.com/api/arkivstruktur/Mappe/a043d07b-9641-44ad-85d8-056730bc8
     "mappeID": "123456/2016",
     "mappetype": {
         "kode": "BYGG",
-        "beskrivelse": "Byggesak"
+        "kodenavn": "Byggesak"
     },
     "tittel", "Testvegen 33, ny enebolig",
     "dokumentmedium": {
         "kode": "E",
-        "beskrivelse": "Elektronisk arkiv"
+        "kodenavn": "Elektronisk arkiv"
     },
     "gradering": {
         "graderingskode": {
@@ -785,7 +795,10 @@ Content-Type: application/vnd.noark5-v4+json
 {
     "saksansvarlig": "Arne",
     "saksdato": "2017-12-08T00:00:00",
-    "saksstatus": { "kode": "R", "beskrivelse": "Opprettet av saksbehandler"}
+    "saksstatus": {
+        "kode": "R",
+	"kodenavn": "Opprettet av saksbehandler"
+    }
 }
 ```
 
@@ -798,7 +811,7 @@ saksmappe og ikke mappe.
     "saksansvarlig": "Henning",
     "saksstatus": {
         "kode": "R",
-        "beskrivelse": "Opprettet av saksbehandler"
+        "kodenavn": "Opprettet av saksbehandler"
     },
     "mappeID": "1/2014",
     "tittel": "klok testmappe 1",
@@ -985,11 +998,11 @@ rettigheter en bruker har? – Arkivverket må avklare dette
     "beskrivelse": "Lorem ipsum",
     "arkivdelstatus": {
         "kode": "",
-        "beskrivelse": ""
+        "kodenavn": ""
     },
     "dokumentmedium": {
         "kode": "",
-        "beskrivelse": ""
+        "kodenavn": ""
     },
     "avsluttetAv": "",
     "referanseAvsluttetAv": "",
@@ -998,7 +1011,7 @@ rettigheter en bruker har? – Arkivverket må avklare dette
     "kassasjon": {
         "kassasjonsvedtak": {
             "kode": "",
-            "beskrivelse": ""
+            "kodenavn": ""
         },
         "kassasjonshjemmel": "",
         "bevaringstid": "",
@@ -1012,7 +1025,7 @@ rettigheter en bruker har? – Arkivverket må avklare dette
     "sletting": {
         "slettingstype": {
             "kode": "SA",
-            "beskrivelse": "Sletting av hele innholdet i arkivdelen"
+            "kodenavn": "Sletting av hele innholdet i arkivdelen"
         },
         "slettedato": "2016-05-02T14:23:27.4065323+02:00",
         "slettetAv": "pålogget bruker"
@@ -1020,19 +1033,19 @@ rettigheter en bruker har? – Arkivverket må avklare dette
     "skjerming": {
         "tilgangsrestrisjon": {
             "kode": "",
-            "beskrivelse": ""
+            "kodenavn": ""
         },
         "skjermingshjemmel": "",
         "skjermingsdokument": {
             "kode": "",
-            "beskrivelse": ""
+            "kodenavn": ""
         },
         "skjermingsvarighet": ""
     },
     "gradering": {
         "graderingskode": {
             "kode": "",
-            "beskrivelse": ""
+            "kodenavn": ""
         },
         "graderingsdato": "0001-01-01T00:00:00",
 ```
@@ -1081,11 +1094,11 @@ GET https://n5.example.com/api/arkivstruktur/Dokumentobjekt/a895c8ed-c15a-43f6-8
     "versjonsnummer": "1",
     "variantformat": {
         "kode": "A",
-        "beskrivelse": "Arkivformat"
+        "kodenavn": "Arkivformat"
     },
     "format": {
         "kode": "fmt/95",
-        "beskrivelse": "PDF/A - ISO 19005-1:2005"
+        "kodenavn": "PDF/A - ISO 19005-1:2005"
     },
     "referanseDokumentfil": "https://n5.example.com/api/arkivstruktur/Dokumentobjekt/a895c8ed-c15a-43f6-86de-86a626433785/referanseFil",
     "_links": {
@@ -1246,11 +1259,11 @@ Respons: 201 Created
     "versjonsnummer": "1",
     "variantformat": {
         "kode": "A",
-        "beskrivelse": "Arkivformat"
+        "kodenavn": "Arkivformat"
     },
     "format": {
         "kode": "RA-JPEG",
-        "beskrivelse": "JPEG (ISO 10918-1:1994)"
+        "kodenavn": "JPEG (ISO 10918-1:1994)"
     },
     "filnavn": "portrait.jpeg",
     "filstoerrelse": 2000000,

--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -1837,7 +1837,16 @@ støtter Admin-pakken:
 | https://rel.arkivverket.no/noark5/v4/api/metadata/tilgangskategori/                   |
 | https://rel.arkivverket.no/noark5/v4/api/metadata/tilgangsrestriksjon/                |
 
-Felles skjema for alle kodelister og felles typer
+Felles skjema for alle kodelister og felles typer.
+
+Verdier fra kodelister henvises til både ved sin **kode** og ved sitt
+**kodenavn**, slik at alle verdier i en bestemt kodeliste må være
+unike.
+
+Alle kodelister har en bolsk attributt «inaktiv» som settes til «true»
+for historiske verdier som ikke lenger skal brukes.  Hvis «inaktiv»
+ikke er satt så er den «false».  Når verdien av «inaktiv» er «false»
+så skal den ikke sendes over i JSON til API-klient.
 
 ![Kodelister - (diagram)](./media/uml-kodelister-entiter.png)
 
@@ -1863,7 +1872,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**            | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ----------------------- | ----------- | ------------ | -------- | -------- |
 | Aktiv periode           |             |              | A        |          |
 | Overlappingsperiode     |             |              | O        |          |
@@ -1890,7 +1899,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**      | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**  | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------- | ----------- | ------------ | -------- | -------- |
 | Opprettet     |             |              | O        |          |
 | Avsluttet     |             |              | A        |          |
@@ -1915,7 +1924,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                  | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**              | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------------- | ----------- | ------------ | -------- | -------- |
 | Besvart med brev          |             |              | BU       |          |
 | Besvart med e-post        |             |              | BE       |          |
@@ -1947,7 +1956,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                            | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | --------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Fysisk medium                           |             |              | F        |          |
 | Elektronisk arkiv                       |             |              | E        |          |
@@ -1973,7 +1982,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                           | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                       | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ---------------------------------- | ----------- | ------------ | -------- | -------- |
 | Dokumentet er under redigering     |             |              | B        |          |
 | Dokumentet er ferdigstilt          |             |              | F        |          |
@@ -1998,7 +2007,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**             | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**         | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | -------------------- | ----------- | ------------ | -------- | -------- |
 | Brev                 | Valgfri     |              | B        |          |
 | Rundskriv            | Valgfri     |              | R        |          |
@@ -2030,7 +2039,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                       | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                   | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ---------------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Symmetrisk kryptert                            | Valgfri     |              | SK       |          |
 | Sendt med PKI/virksomhetssertifikat            | Valgfri     |              | V        |          |
@@ -2059,7 +2068,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                             | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                         | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------------------------ | ----------- | ------------ | -------- | -------- |
 | Signatur påført, ikke verifisert     |             |              | I        |          |
 | Signatur påført og verifisert        |             |              | V        |          |
@@ -2080,7 +2089,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                            | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                        | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | --------------------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Godkjent                                            | Valgfri     |              | G        |          |
 | Ikke godkjent                                       | Valgfri     |              | I        |          |
@@ -2130,7 +2139,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                 | **Merknad**                                                                                                                                                              | **Multipl.** | **Kode**  | **Type** |
+| **Kodenavn**             | **Merknad**                                                                                                                                                              | **Multipl.** | **Kode**  | **Type** |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | --------- | -------- |
 | Ren tekst                | Som ren tekst: UTF-8 (ISO/IEC 10646-1:2000 Annex D) eller ISO 8859-1:1998, Latin 1. ISO 8859-1:1998, Latin 1 kan erstattes med ISO 8859-4:1998, Latin 4 for samiske tegn |              | [fmt/111](http://www.nationalarchives.gov.uk/PRONOM/fmt/111)   |          |
 | TIFF versjon 6           | TIFF - Tag Image File Format versjon 6, med de presiseringer som fremgår av forskriftens § 8-18                                                                          |              | [fmt/353](http://www.nationalarchives.gov.uk/PRONOM/fmt/353)  |          |
@@ -2159,7 +2168,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                 | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                             | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ---------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Strengt hemmelig (sikkerhetsgrad)        |             |              | SH       |          |
 | Hemmelig (sikkerhetsgrad)                |             |              | H        |          |
@@ -2182,7 +2191,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**            | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**        | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------- | ----------- | ------------ | -------- | -------- |
 | Endringslogg        |             |              |          |          |
 | Søknad mottatt      |             |              |          |          |
@@ -2210,7 +2219,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                  | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                              | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ----------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Inngående dokument                        |             |              | I        |          |
 | Utgående dokument                         |             |              | U        |          |
@@ -2237,7 +2246,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                            | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                        | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | --------------------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Journalført                                         |             |              | J        |          |
 | Ferdigstilt fra saksbehandler                       |             |              | F        |          |
@@ -2271,7 +2280,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**            | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**        | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------- | ----------- | ------------ | -------- | -------- |
 | Bevares             |             |              | B        |          |
 | Kasseres            |             |              | K        |          |
@@ -2298,7 +2307,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                               | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                           | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | -------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Gårds- og bruksnummer                  | Valgfri     |              | GBN      |          |
 | Funksjonsbasert, hierarkisk            | Valgfri     |              | FH       |          |
@@ -2330,7 +2339,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**            | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ----------------------- | ----------- | ------------ | -------- | -------- |
 | Avsender                |             |              | EA       |          |
 | Mottaker                |             |              | EM       |          |
@@ -2390,7 +2399,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                       | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                   | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------------------ | ----------- | ------------ | -------- | -------- |
 | Merknad fra saksbehandler      | Valgfri     |              | MS       |          |
 | Merknad fra leder              | Valgfri     |              | ML       |          |
@@ -2417,7 +2426,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**      | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**  | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------- | ----------- | ------------ | -------- | -------- |
 | Møteleder     | Valgfri     |              | M        |          |
 | Referent      | Valgfri     |              | R        |          |
@@ -2448,7 +2457,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                            | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | --------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Ferdig behandlet av utvalget            | Valgfri     |              | BE       |          |
 | Utsatt til nytt møte i samme utvalg     | Valgfri     |              | UT       |          |
@@ -2482,7 +2491,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                | **Merknad**                                                                                                                     | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**            | **Merknad**                                                                                                                     | **Multipl.** | **Kode** | **Type** |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------ | -------- | -------- |
 | Møteinnkalling          |                                                                                                                                 |              | MI       |          |
 | Saksframlegg            |                                                                                                                                 |              | SF       |          |
@@ -2514,7 +2523,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                         | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                     | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | -------------------------------- | ----------- | ------------ | -------- | -------- |
 | Politisk sak                     |             |              | PS       |          |
 | Delegert møtesak                 |             |              | DS       |          |
@@ -2563,7 +2572,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**      | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**  | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------- | ----------- | ------------ | -------- | -------- |
 | Gjeldende     |             |              | G        |          |
 | Foreldet      |             |              | F        |          |
@@ -2584,7 +2593,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**      | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**  | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------- | ----------- | ------------ | -------- | -------- |
 | Klient        | Valgfri     |              | KLI      |          |
 | Pårørende     | Valgfri     |              | PÅ       |          |
@@ -2612,7 +2621,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                        | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                    | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------------------- | ----------- | ------------ | -------- | -------- |
 | Under behandling                |             |              | B        |          |
 | Avsluttet                       |             |              | A        |          |
@@ -2643,7 +2652,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                             | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                         | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------------------------ | ----------- | ------------ | -------- | -------- |
 | Skjerming av hele dokumentet         |             |              | H        |          |
 | Skjerming av deler av dokumentet     |             |              | D        |          |
@@ -2669,7 +2678,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                                 | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                             | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | -------------------------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Skjerming klasseID                                       |             |              | KID      |          |
 | Skjerming tittel klasse                                  |             |              | TKL      |          |
@@ -2704,7 +2713,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                        | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                    | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ----------------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Sletting av produksjonsformat                   |             |              | SP       |          |
 | Sletting av tidligere versjon                   |             |              | SV       |          |
@@ -2759,7 +2768,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**            | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ----------------------- | ----------- | ------------ | -------- | -------- |
 | arkivdel                |             |              | A        |          |
 | klasse                  |             |              | K        |          |
@@ -2783,7 +2792,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                           | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                       | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | -------------------------------------------------- | ----------- | ------------ | -------- | -------- |
 | Begrenset etter sikkerhetsinstruksen               |             |              | B        |          |
 | Konfidensielt etter sikkerhetsinstruksen           |             |              | K        |          |
@@ -2814,7 +2823,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**          | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**      | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ----------------- | ----------- | ------------ | -------- | -------- |
 | Hoveddokument     |             |              | H        |          |
 | Vedlegg           |             |              | V        |          |
@@ -2839,7 +2848,7 @@ Table: Relasjonsnøkler
 
 Table: Attributter
 
-| **Navn**                                         | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| **Kodenavn**                                     | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------------------------------------ | ----------- | ------------ | -------- | -------- |
 | Produksjonsformat                                |             |              | P        |          |
 | Arkivformat                                      |             |              | A        |          |


### PR DESCRIPTION
Forklare bedre hvordan kodeliste-verdier settes og overføres, og
introduser en ny bolsk kodeliste-attributt «inaktiv» for
å kunne fase ut verdier som allerede er i bruk.

Korrigerer også noen feilaktige relasjonsnøkler i kapittel 6.

Fixes #148
Fixes #202