### PR TITLE
Fjern pakken Moeter

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -844,7 +844,7 @@ det mangler påkrevde felter.
 
 Noen entiteter kan ha samme type entitet under seg, og slik danne et
 rekursivt hierarki av instanser.  Det gjelder Arkiv, Klasse og Mappe,
-og entiter som arver fra disse (som Saksmappe og Moetemappe).
+og entiter som arver fra disse (som Saksmappe).
 
 Da det ikke er i tråd med HATEOAS-prinsippene å la samme
 relasjonsnøkkel peke til flere ulike href-er, så må dette håndteres

--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -7,7 +7,7 @@
 | ![](./media/uml-forklaring-om-notasjon-som-er-brukt.png) | ***Klassediagram*** brukes for å vise utvalgte klasser i en UML-modell. Klassediagram ***trenger ikke være fullstendige***, hverken mhp hvilke klasser som vises eller hvilke assosiasjoner som vises. For kompliserte modeller (som NOARK-modellen) trengs flere klassediagram for å vise hele modellen. |
 |![](./media/uml-klasse-konspetet-bruker-registrering-som-eksempel.png) |I et ***klassediagram*** vises en klasse som en firkantet boks. ***Klassenavnet*** står i øverste «etasje», og er i eksempelet Registrering. ***Klasseattributtene*** karakteriserer klassen, og listes opp en i nest øverste etasje (i eksempelet i alt 7, den første/øverste har navnet arkivertDato). Firkanten kan også ha flere frivillige etasjer for å vise mer informasjon. I klassen Registrering vises en «etasje» med notes (ofte brukt for ***klassedefinisjon***) |
 |![](./media/uml-assosiasjoner-brukt-med-klasser.png) | Klasser kan knyttes sammen med ***assosiasjoner***. Assosiasjoner vises som streker mellom to klasser. En assosiasjon der begge ender er knytta til samme klasse kalles ***selv-assosiasjon***. Eksempel: Mappe kan ha undermappe med samme struktur som mappa selv. Dette brukes der en trenger et hierarki av like klasser. En assosiasjon kan være ***aggregering***. Symbolet er en strek mellom to klasser med åpen diamant i ene enden. Eksempel: Ei Mappe ***har*** Registrering(er). En registrering er en selvstendig enhet, som «overlever» selv om Mappa blir sletta. |
-|![](./media/uml-generalisering-brukt-med-klasser.png) | Assosiasjoner kan være ***generalisering/spesialisering***. Symbolet er en strek med en trekant i ene enden. Eksempel er Registrering som er en generalisering av Journalpost og Moeteregistrering. En kan også si at Journalpost er en spesialisering av Registrering. I Registrering legges alle felles-kjennetegnene. Felleskjennetegnene arves så ned på Journalpost og Moeteregistrering. Dette leses som Journalpost ***er en*** Registrering. Dersom en klasse er en spesialisering av en annen klasse som ikke er tatt med i diagrammet, skrives ofte navnet på den generaliserte klassen i øvre høyre hjørne av klasse-firkanten. I eksempelet kan vi derfor se at Registrering er en spesialisering av Arkivenhet, selv om klassen Arkivenhet ikke finnes i diagrammet. |
+|![](./media/uml-generalisering-brukt-med-klasser.png) | Assosiasjoner kan være ***generalisering/spesialisering***. Symbolet er en strek med en trekant i ene enden. Eksempel er Registrering som er en generalisering av Journalpost. En kan også si at Journalpost er en spesialisering av Registrering. I Registrering legges alle felles-kjennetegnene. Felleskjennetegnene arves så ned på Journalpost. Dette leses som Journalpost ***er en*** Registrering. Dersom en klasse er en spesialisering av en annen klasse som ikke er tatt med i diagrammet, skrives ofte navnet på den generaliserte klassen i øvre høyre hjørne av klasse-firkanten. I eksempelet kan vi derfor se at Registrering er en spesialisering av Arkivenhet, selv om klassen Arkivenhet ikke finnes i diagrammet. |
 |![](./media/uml-komposisjon-brukt-med-klasser.png) | En assosiasjon kan også være ***komposisjon***. Symbolet er en strek mellom to klasser med lukka diamant i den ene enden. En Registrering ***har*** Korrespondansepart(er). En slik Korrespondansepart kan ikke eksistere uten at den er knytta til en Registrerign. Slettes («dør») Registreringen vil også korrespondanseparten bli sletta («vil dø»). Assosiasjonene forteller også hvilken vei de er ***navigerbare***. Symbolet for dette er piler i endene på streken. Eksempel: En registrering «vet» hvilke korrespondansepart(er) som tilhører registreringen, mens korrespondanseparten ikke vet hvilken registrering den tilhører.|
 |![](./media/uml-multiplisitet-brukt-med-klasser.png) | ***Multiplisiteten*** forteller hvor mange forekomster som kan inngå. Multiplisitet kan brukes i forbindelse med assosiasjoner og også på klasseattributter. Dette vises med minst ett tall, men ofte to tall med to prikker mellom (0..1). Det første tallet angir minimums-multiplisitet (så mange det minst må være), det andre tallet er maksimumsmultiplisitet (så mange det maksimalt kan være). Eksempel: En Mappe kan høre til ingen eller en (0..1) Klasse, mens en Klasse kan «ha» ingen eller flere (0..***) Mapper(er). Stjernesymbol brukes til å angi «mange» (ubestemt tall større enn 1).En klasseattributt har angitt multiplisitet med klammeparenteser (\[0..1\]). Klasseattributten noekkelord kan forekomme ingen eller en gang. Når det ikke er angitt multiplisitet, skal dette oftest tolkes som (1..1). En Klasse skal alltid ha en klasseID, og kan bare ha en. En tom tekststreng-verdi ("") og en tekststreng som kun inneholder usynlige tegn (definert som beskrevet i vedlegg 5) er likestilt med en manglende verdi, slik at ved multiplisiteten [1..1] betyr det at klasseID også må ha en verdi forskjellig fra tom streng.|
 |![](./media/uml-simple-datatyper-eller-primitiver.png) | Datatypene kan også være ***simple datatyper*** eller ***primitiver***. Disse brukes for å gi mulighet for restriksjoner også på primitivene. Epostadresse kan være modellert som en slik primitiv. Epost er en tekst-streng, men som i tillegg til å være tekst-streng også må oppfylle visse regler knytta til det å være gyldig epostadresse (bl.a. inneholde en og bare en forekomst av tegnet @). I eksempelet i figuren er SystemID en tekststreng (string) som i tillegg må oppfylle tilleggskrav. I store modeller kan det være hensiktsmessig å plassere ulike modell-elementer i ulike pakker. Da kan det også bli lettere for leseren å forstå modellen når han får vite hvilken pakke de ulike klassene er plassert i. Modellpakker kalles ofte ***navnerom*** (namespace) Dette kan angis foran klassenavnet, skilt fra klassenavnet med kolon (:). I eksempelet hører klassen SystemID til pakken/navnerommet Metadata og klassen string tilhører pakken/navnerommet BasicTypes.|
@@ -520,7 +520,6 @@ Table: Relasjoner
 | **Association** (Destination → Source)     | korrespondansepart 0..* Korrespondansepart               | Registrering         |             |
 | **Association** (Destination → Source)     | part 0..* Part                                           | Registrering         |             |
 | **Association** (Bi-Directional)           | kryssreferanse 0..* Kryssreferanse                       | registrering 0..1 Registrering ||
-| **Generalization** (Source → Destination)  | Moeteregistrering                                         | Registrering      |             |
 | **Generalization** (Source → Destination)  | Journalpost                                              | Registrering      |             |
 | **Association** (Destination → Source)     | merknad 0..* Merknad                                     | Registrering      |             |
 
@@ -1086,7 +1085,7 @@ klasse, mappe og registrering. Referansen går en vei, dvs. den
 kan kun være en referanse til en arkivenhet. I og med at
 kryssreferanser knyttes til Mappe og Registrering, vil det si at
 Referanser også knyttes til alle utvidelsene (spesialiseringer) under
-disse (Saksmappe, Moetemappe og Journalpost, Moeteregistrering).
+disse (Saksmappe og Journalpost).
 
 Ved avlevering i tråd med XML-skjema for Noark 5 versjon 5 så droppes
 samtlige felt arvet fra Arkivenhet, da disse ikke har korresponderende
@@ -1171,7 +1170,6 @@ Table: Relasjoner
 | **Aggregation** (Destination → Source)     | nasjonalidentifikator 0..* Nasjonalidentifikator         | Mappe                  |             |
 | **Association** (Source → Destination)     | Mappe                                                    | merknad 0..* Merknad   |             |
 | **Association** (Source → Destination)     | Mappe                                                    | part 0..* Part         |             |
-| **Generalization** (Source → Destination)  | Moetemappe                                                | Mappe                  |             |
 | **Generalization** (Source → Destination)  | Saksmappe                                                | Mappe                  |             |
 | **Association** (Bi-Directional)           | kryssreferanse 0..* Kryssreferanse                       | mappe 0..1 Mappe       |             |
 
@@ -1193,7 +1191,6 @@ Table: Relasjonsnøkler
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/overmappe/                |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/undermappe/               |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-journalpost/           |
-| REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-moeteregistrering/     |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/nasjonalidentifikator/    |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/bygning/                  |
 | REST\_REL | https://rel.arkivverket.no/noark5/v4/api/arkivstruktur/ny-bygning/               |
@@ -1762,16 +1759,6 @@ støtter Sakarkiv-pakken:
 | https://rel.arkivverket.no/noark5/v4/api/metadata/presedensstatus/                    |
 | https://rel.arkivverket.no/noark5/v4/api/metadata/sakspartrolle/                      |
 | https://rel.arkivverket.no/noark5/v4/api/metadata/saksstatus/                         |
-
-Følgende relasjonsnøkler skal listes opp fra en implementasjon som
-støtter Moeter-pakken:
-
-| **Relasjonsnøkkel**                                                           |
-|-------------------------------------------------------------------------------|
-| https://rel.arkivverket.no/noark5/v4/api/metadata/moetedeltakerfunksjon/              |
-| https://rel.arkivverket.no/noark5/v4/api/metadata/moeteregistreringsstatus/           |
-| https://rel.arkivverket.no/noark5/v4/api/metadata/moeteregistreringstype/             |
-| https://rel.arkivverket.no/noark5/v4/api/metadata/moetesakstype/                      |
 
 Følgende relasjonsnøkler skal listes opp fra en implementasjon som
 støtter LoggingOgSporing-pakken:
@@ -2355,131 +2342,6 @@ Table: Attributter
 | Merknad fra saksbehandler      | Valgfri     |              | MS       |          |
 | Merknad fra leder              | Valgfri     |              | ML       |          |
 | Merknad fra arkivansvarlig     | Valgfri     |              | MA       |          |
-
-#### MoetedeltakerFunksjon
-
-*Type:* ***Class «codelist»***
-
-*Arver:* 
-
-Åpen kodeliste
-
-Definisjon: Funksjon eller rolle til personen som deltok på møtet
-
-M373
-moetedeltakerFunksjon
-
-Table: Relasjonsnøkler
-
-| **Tag**  | **Verdi**                                                        |
-| -------- | ---------------------------------------------------------------- |
-| codeList | https://rel.arkivverket.no/noark5/v4/api/metadata/moetedeltakerfunksjon/ |
-
-Table: Attributter
-
-| **Kodenavn**  | **Merknad** | **Multipl.** | **Kode** | **Type** |
-| ------------- | ----------- | ------------ | -------- | -------- |
-| Møteleder     | Valgfri     |              | M        |          |
-| Referent      | Valgfri     |              | R        |          |
-
-#### Moeteregistreringsstatus
-
-*Type:* ***Class «codelist»***
-
-*Arver:* 
-
-Åpen kodeliste
-
-Definisjon: Status til møteregistreringen. Kilde: (ingen)
-
-Kommentar: Valgfrie verdier, eksempler:
-
- - "Ferdig behandlet av utvalget"
- - "Utsatt til nytt møte i samme utvalg"
- - "Sendt tilbake til foregående utvalg"
-
-M055 moeteregistreringsstatus
-
-Table: Relasjonsnøkler
-
-| **Tag**  | **Verdi**                                                           |
-| -------- | ------------------------------------------------------------------- |
-| codeList | https://rel.arkivverket.no/noark5/v4/api/metadata/moeteregistreringsstatus/ |
-
-Table: Attributter
-
-| **Kodenavn**                            | **Merknad** | **Multipl.** | **Kode** | **Type** |
-| --------------------------------------- | ----------- | ------------ | -------- | -------- |
-| Ferdig behandlet av utvalget            | Valgfri     |              | BE       |          |
-| Utsatt til nytt møte i samme utvalg     | Valgfri     |              | UT       |          |
-| Sendt tilbake til foregående utvalg     | Valgfri     |              | TB       |          |
-
-#### Moeteregistreringstype
-
-*Type:* ***Class «codelist»***
-
-*Arver:* 
-
-Definisjon: Navn på type møteregistrering
-
-Kommentar: utvidet i forhold til forslagene i NOARK 5 Vedlegg 1
-
-Vedlegg 1 Metadatakatalog v 3.1, M085 lister følgende "aktuelle
-verdier":
-
- - Møteinnkallelse
- - Saksliste
- - Saksframlegg
- - Vedlegg til møtesak
-
-M085 moeteregistreringstype
-
-Table: Relasjonsnøkler
-
-| **Tag**  | **Verdi**                                                         |
-| -------- | ----------------------------------------------------------------- |
-| codeList | https://rel.arkivverket.no/noark5/v4/api/metadata/moeteregistreringstype/ |
-
-Table: Attributter
-
-| **Kodenavn**            | **Merknad**                                                                                                                     | **Multipl.** | **Kode** | **Type** |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------ | -------- | -------- |
-| Møteinnkalling          |                                                                                                                                 |              | MI       |          |
-| Saksframlegg            |                                                                                                                                 |              | SF       |          |
-| Saksprotokoll           |                                                                                                                                 |              | SP       |          |
-| Møteprotokoll           |                                                                                                                                 |              | MP       |          |
-| Saksliste               |                                                                                                                                 |              | SL       |          |
-| Offentlig saksliste     | Offentlig saksliste, dvs en saksliste hvor informasjon (vanligvis kun i sakstittel) som skal unntas offentligheten, er skjermet |              | OL       |          |
-| Vedlegg til møtesak     |                                                                                                                                 |              | VL       |          |
-
-#### Moetesakstype
-
-*Type:* ***Class «codelist»***
-
-*Arver:* 
-
-Åpen kodeliste
-
-Definisjon: Navn på type møtesak. Kilde: (ingen)
-
-Kommentar: (ingen)
-
-M088 moetesakstype
-
-Table: Relasjonsnøkler
-
-| **Tag**  | **Verdi**                                                |
-| -------- | -------------------------------------------------------- |
-| codeList | https://rel.arkivverket.no/noark5/v4/api/metadata/moetesakstype/ |
-
-Table: Attributter
-
-| **Kodenavn**                     | **Merknad** | **Multipl.** | **Kode** | **Type** |
-| -------------------------------- | ----------- | ------------ | -------- | -------- |
-| Politisk sak                     |             |              | PS       |          |
-| Delegert møtesak                 |             |              | DS       |          |
-| Referatsak                       |             |              | RS       |          |
-| Forespørsel (interpellasjon)     |             |              | FO       |          |
 
 #### Postnummer
 


### PR DESCRIPTION
Hans Fredrik i Arkivverket har i mangelmelding #96 bedt om at
Moete-pakken tas ut av spesifikasjonen.  Her er endringene som
gjennomfører denne endringen.

Jeg oppdaterer endringsforslag #120 med de endringene som trengs
for å få den tilbake.