### PR TITLE
Flytt Part, Korrespondansepart, EnkelAdresse og Kontaktinformasion

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -811,6 +811,33 @@ Table: Restriksjoner
 | M622 verifisertDato: kan ikke endres | verifisertDato: kan ikke endres |
 | M623 verifisertAv: Kan ikke endres   |                                 |
 
+#### EnkelAdresse
+
+*Type:* ***Class «dataType»***
+
+*Arver:*
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                          |
+| ------------------------------------------------------------------ |
+| self                                                               |
+| https://rel.arkivverket.no/noark5/v5/api/metadata/land/            |
+| https://rel.arkivverket.no/noark5/v5/api/metadata/postnummer/      |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/enkeladresse/    |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-enkeladresse/ |
+
+Table: Attributter
+
+| **Navn**          | **Merknad** | **Multipl.** | **Kode** | **Type**   |
+| ----------------- | ----------- | ------------ | -------- | ---------- |
+| adresselinje1     |             | \[0..1\]     |          | string     |
+| adresselinje2     |             | \[0..1\]     |          | string     |
+| adresselinje3     |             | \[0..1\]     |          | string     |
+| postnr            |             | \[0..1\]     |          | Postnummer |
+| poststed          |             | \[1..1\]     |          | string     |
+| landkode          |             | \[0..1\]     |          | Land       |
+
 #### Gradering
 
 *Type:* ***Class «dataType»***
@@ -1020,6 +1047,28 @@ Table: Restriksjoner
 | ------------------------------------------------- | ----------- |
 | M020 tittel: Skal normalt ikke kunne endres etter at enheten er lukket, eller  dokumentene arkivert | |
 
+#### Kontaktinformasjon
+
+*Type:* ***Class «dataType»***
+
+*Arver:*
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                                |
+| ------------------------------------------------------------------------ |
+| self                                                                     |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/kontaktinformasjon/    |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-kontaktinformasjon/ |
+
+Table: Attributter
+
+| **Navn**         | **Merknad** | **Multipl.** | **Kode** | **Type** |
+| ---------------- | ----------- | ------------ | -------- | -------- |
+| epostadresse     |             | \[0..1\]     |          | string   |
+| mobiltelefon     |             | \[0..1\]     |          | string   |
+| telefon          |             | \[0..1\]     |          | string   |
+
 #### Konvertering
 
 *Type:* ***Class***
@@ -1067,6 +1116,139 @@ Table: Restriksjoner
 | M616 konvertertAv: Kan ikke endres        |             |
 | M712 konvertertFraFormat: Kan ikke endres |             |
 | M713 konvertertTilFormat: Kan ikke endres |             |
+
+#### Korrespondansepart
+
+*Type:* ***Class***
+
+*Arver:* 
+
+Korrespondansepart er obligatorisk, og skal forekomme en eller flere
+ganger i en journalpost.  Ved inngående dokumenter er det obligatorisk
+å registrere avsender(e), ved utgående dokumenter mottaker(e). Ved
+organinterne dokumenter som skal følges opp, må både avsender(e) og
+mottaker(e) registreres.
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | KorrespondansepartEnhet                                  | Korrespondansepart     |             |
+| **Generalization** (Source → Destination)  | KorrespondansepartPerson                                 | Korrespondansepart     |             |
+| **Generalization** (Source → Destination)  | KorrespondansepartIntern                                 | Korrespondansepart     |             |
+| **Association** (Destination → Source)     | korrespondansepart 1..* Korrespondansepart               | Registrering         |             |
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                                 |
+| ------------------------------------------------------------------------- |
+| self                                                                      |
+| https://rel.arkivverket.no/noark5/v5/api/metadata/korrespondanseparttype/ |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepart/     |
+
+Table: Attributter
+
+| **Navn**  | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
+|-----------|---------------|---------------|-----------|-----------|
+| systemID                      | Definisjon: Entydig identifikasjon av arkivenheten innenfor det arkivskapende organet. Dersom organet har flere arkivsystemer, skal altså systemID være gjennomgående entydig. Systemidentifikasjonen vil som oftest være en nummerisk kode uten noe logisk meningsinnhold. Identifikasjonen trenger ikke å være synlig for brukerne. Kilde: Registreres automatisk av systemet Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkivenhetens systemidentifikasjon. Dette gjelder også referanser fra en arkivdel til en annen, f.eks. mellom to arkivperioder som avleveres på forskjellig tidspunkt. I et arkivuttrekk skal systemID være entydig (unik). Dokumentobjekt har ingen systemidentifikasjon fordi enheten kan være duplisert i et arkivuttrekk dersom samme dokumentfil er knyttet til flere forskjellige registreringer. M001 | \[0..1\] | | SystemID |
+| korrespondanseparttype        | Definisjon: Type korrespondansepart . Kilde: Registreres automatisk knyttet til funksjonalitet i forbindelse med opprettelse av journalpost, kan også registreres  manuelt. Kommentarer: Korrespondansetype forekommer én gang innenfor objektet korrespondansepart, men denne kan forekomme flere ganger innenfor en journalpost. M087 | \[1..1\] | | Korrespondanseparttype|
+| virksomhetsspesifikkeMetadata | Definisjon: Et overordnet metadataelement som kan inneholde egendefinerte metadata. Disse metadataene må da være spesifisert i et eller flere XML-skjema. Kilde: (ingen). Kommentar: (ingen). M711 virksomhetsspesifikkeMetadata | \[0..1\] | | any |
+
+Table: Restriksjoner
+
+| **Navn**                              | **Merknad** |
+| ------------------------------------- | ----------- |
+| M001 systemID: Skal ikke kunne endres |             |
+
+#### KorrespondansepartEnhet
+
+*Type:* ***Class***
+
+*Arver:* ***Korrespondansepart***
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | KorrespondansepartEnhet                                  | Korrespondansepart     |             | 
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                                     |
+| ----------------------------------------------------------------------------- |
+| self                                                                          |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepartenhet/    |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-korrespondansepartenhet/ |
+
+Table: Attributter
+
+| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type**           |
+| ----------------------- | ----------- | ------------ | -------- | ------------------ |
+| enhetsidentifikator     |             | \[0..1\]     |          | Enhetsidentifikator|
+| navn                    |             | \[1..1\]     |          | string             |
+| forretningsadresse      |             | \[0..1\]     |          | EnkelAdresse       |
+| postadresse             |             | \[0..1\]     |          | EnkelAdresse       |
+| kontaktinformasjon      |             | \[0..1\]     |          | Kontaktinformasjon |
+| kontaktperson           |             | \[0..1\]     |          | string             |
+
+#### KorrespondansepartIntern
+
+*Type:* ***Class***
+
+*Arver:* ***Korrespondansepart***
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | KorrespondansepartIntern                                 | Korrespondansepart     |             |
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                                      |
+| ------------------------------------------------------------------------------ |
+| self                                                                           |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepartintern/    |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-korrespondansepartintern/ |
+
+Table: Attributter
+
+| **Navn**                        | **Merknad**                                   | **Multipl.** | **Kode** | **Type** |
+| ------------------------------- | --------------------------------------------- | ------------ | -------- | -------- |
+| administrativEnhet              |                                               | \[0..1\]     |          | string   |
+| referanseAdministrativEnhet     | referanse til AdministrativEnhet sin systemID | \[0..1\]     |          | SystemID |
+| saksbehandler                   |                                               | \[0..1\]     |          | string   |
+| referanseSaksbehandler          | referanse til Bruker sin systemID             | \[0..1\]     |          | SystemID |
+
+#### KorrespondansepartPerson
+
+*Type:* ***Class***
+
+*Arver:* ***Korrespondansepart***
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | KorrespondansepartPerson                                 | Korrespondansepart     |             |
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                                      |
+| ------------------------------------------------------------------------------ |
+| self                                                                           |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepartperson/    |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-korrespondansepartperson/ |
+
+Table: Attributter
+
+| **Navn**               | **Merknad** | **Multipl.** | **Kode** | **Type**           |
+| ---------------------- | ----------- | ------------ | -------- | ------------------ |
+| personidentifikator    |             | \[0..*\]     |          | Personidentifikator|
+| navn                   |             | \[1..1\]     |          | string             |
+| postadresse            |             | \[0..1\]     |          | EnkelAdresse       |
+| bostedsadresse         |             | \[0..1\]     |          | EnkelAdresse       |
+| kontaktinformasjon     |             | \[0..1\]     |          | Kontaktinformasjon |
 
 #### Kryssreferanse
 
@@ -1418,6 +1600,114 @@ Table: Restriksjoner
 | M001 systemID: Skal ikke kunne endres     |             |
 | M611 merknadsdato: Kan ikke endres        |             |
 | M612 merknadRegistrertAv: Kan ikke endres |             |
+
+#### Part
+
+*Type:* ***Class***
+
+*Arver:* 
+
+En eller flere virksomheter eller personer kan være knyttet til en
+mappe eller registrering som parter.
+
+Metadata for part skal kunne grupperes inn i metadata for mappe og
+registrering.  Part er valgfritt, og kan forekomme en eller flere
+ganger i tilknytning til en mappe og registrering.  Dersom det er mer
+enn én part, må metadataene grupperes sammen ved eksport og
+utveksling.
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | PartPerson                                           | Part               |             |
+| **Generalization** (Source → Destination)  | PartEnhet                                            | Part               |             |
+| **Association** (Destination → Source)     | part 0..* Part                                     | Mappe                |             |
+| **Association** (Destination → Source)     | part 0..* Part                                     | Registrering         |             |
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                    |
+| ------------------------------------------------------------ |
+| self                                                         |
+| https://rel.arkivverket.no/noark5/v5/api/metadata/partrolle/ |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-part/   |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/part/      |
+
+Table: Attributter
+
+| **Navn**  | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
+|-----------|---------------|---------------|-----------|-----------|
+| systemID                      | Definisjon: Entydig identifikasjon av arkivenheten innenfor det arkivskapende organet. Dersom organet har flere arkivsystemer, skal altså systemID være gjennomgående entydig. Systemidentifikasjonen vil som oftest være en nummerisk kode uten noe logisk meningsinnhold. Identifikasjonen trenger ikke å være synlig for brukerne. Kilde: Registreres automatisk av systemet Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkivenhetens systemidentifikasjon. Dette gjelder også referanser fra en arkivdel til en annen, f.eks. mellom to arkivperioder som avleveres på forskjellig tidspunkt. I et arkivuttrekk skal systemID være entydig (unik). Dokumentobjekt har ingen systemidentifikasjon fordi enheten kan være duplisert i et arkivuttrekk dersom samme dokumentfil er knyttet til flere forskjellige registreringer. M001 | \[0..1\] | | SystemID |
+| partRolle                 | Definisjon: Angivelse av rollen til parten . Kilde: Registreres manuelt eller automatisk fra fagsystem. Kommentarer: (ingen). Betingelser: Her er det mange tenkelige roller avhengig av type sak, f.eks. Klient, Pårørende, Formynder, Advokat. M303 | \[1..1\] | | PartRolle |
+| virksomhetsspesifikkeMetadata |  | \[0..1\] | | any |
+
+Table: Restriksjoner
+
+| **Navn**                              | **Merknad** |
+| ------------------------------------- | ----------- |
+| M001 systemID: Skal ikke kunne endres |             |
+
+#### PartEnhet
+
+*Type:* ***Class***
+
+*Arver:* ***Part***
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | PartEnhet                                            | Part               |             |
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                       |
+| --------------------------------------------------------------- |
+| self                                                            |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-partenhet/ |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/partenhet/    |
+
+Table: Attributter
+
+| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type**           |
+| ----------------------- | ----------- | ------------ | -------- | ------------------ |
+| enhetsidentifikator     |             | \[0..1\]     |          | Enhetsidentifikator|
+| navn                    |             | \[1..1\]     |          | string             |
+| forretningsadresse      |             | \[0..1\]     |          | EnkelAdresse       |
+| postadresse             |             | \[0..1\]     |          | EnkelAdresse       |
+| kontaktinformasjon      |             | \[0..1\]     |          | Kontaktinformasjon |
+| kontaktperson           |             | \[0..1\]     |          | string             |
+
+#### PartPerson
+
+*Type:* ***Class***
+
+*Arver:* ***Part***
+
+Table: Relasjoner
+
+| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
+| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
+| **Generalization** (Source → Destination)  | PartPerson                                           | Part               |             |
+
+Table: Relasjonsnøkler
+
+| **Verdi**                                                        |
+| ---------------------------------------------------------------- |
+| self                                                             |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-partperson/ |
+| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/partperson/    |
+
+Table: Attributter
+
+| **Navn**               | **Merknad** | **Multipl.** | **Kode** | **Type**           |
+| ---------------------- | ----------- | ------------ | -------- | ------------------ |
+| personidentifikator    |             | \[0..*\]     |          | Personidentifikator|
+| navn                   |             | \[1..1\]     |          | string             |
+| postadresse            |             | \[0..1\]     |          | EnkelAdresse       |
+| bostedsadresse         |             | \[0..1\]     |          | EnkelAdresse       |
+| kontaktinformasjon     |             | \[0..1\]     |          | Kontaktinformasjon |
 
 #### Skjerming
 
@@ -2915,33 +3205,6 @@ Table: Restriksjoner
 | M662 flytSendtDato: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke kunne endres. | |
 | M665 flytFra: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke kunne endres. | |
 
-#### EnkelAdresse
-
-*Type:* ***Class «dataType»***
-
-*Arver:*
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                          |
-| ------------------------------------------------------------------ |
-| self                                                               |
-| https://rel.arkivverket.no/noark5/v5/api/metadata/land/            |
-| https://rel.arkivverket.no/noark5/v5/api/metadata/postnummer/      |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/enkeladresse/    |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-enkeladresse/ |
-
-Table: Attributter
-
-| **Navn**          | **Merknad** | **Multipl.** | **Kode** | **Type**   |
-| ----------------- | ----------- | ------------ | -------- | ---------- |
-| adresselinje1     |             | \[0..1\]     |          | string     |
-| adresselinje2     |             | \[0..1\]     |          | string     |
-| adresselinje3     |             | \[0..1\]     |          | string     |
-| postnr            |             | \[0..1\]     |          | Postnummer |
-| poststed          |             | \[1..1\]     |          | string     |
-| landkode          |             | \[0..1\]     |          | Land       |
-
 #### Arkivnotat
 
 *Type:* ***Class***
@@ -3079,161 +3342,6 @@ Table: Restriksjoner
 | M106 utlaantDato: Utlån skal også kunne registreres etter at en saksmappe er avsluttet, eller etter at dokumentene i en journalpost ble arkivert. | |
 | M308 journalenhet: Er ikke lenger obligatorisk i Noark 5. Journalenhet er helt uavhengig av administrativ enhet. Kan f.eks. brukes som seleksjonskriterium ved produksjon av rapporter. Det anbefales ikke å knytte tilgangsrettigheter til journalenhet. | |
 | M309 utlaantTil: Utlån skal også kunne registreres etter at en saksmappe er avsluttet, eller at dokumentene i en journalpost ble arkivert. |
-
-#### Kontaktinformasjon
-
-*Type:* ***Class «dataType»***
-
-*Arver:*
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                                |
-| ------------------------------------------------------------------------ |
-| self                                                                     |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/kontaktinformasjon/    |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-kontaktinformasjon/ |
-
-Table: Attributter
-
-| **Navn**         | **Merknad** | **Multipl.** | **Kode** | **Type** |
-| ---------------- | ----------- | ------------ | -------- | -------- |
-| epostadresse     |             | \[0..1\]     |          | string   |
-| mobiltelefon     |             | \[0..1\]     |          | string   |
-| telefon          |             | \[0..1\]     |          | string   |
-
-#### Korrespondansepart
-
-*Type:* ***Class***
-
-*Arver:* 
-
-Korrespondansepart er obligatorisk, og skal forekomme en eller flere
-ganger i en journalpost.  Ved inngående dokumenter er det obligatorisk
-å registrere avsender(e), ved utgående dokumenter mottaker(e). Ved
-organinterne dokumenter som skal følges opp, må både avsender(e) og
-mottaker(e) registreres.
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | KorrespondansepartEnhet                                  | Korrespondansepart     |             |
-| **Generalization** (Source → Destination)  | KorrespondansepartPerson                                 | Korrespondansepart     |             |
-| **Generalization** (Source → Destination)  | KorrespondansepartIntern                                 | Korrespondansepart     |             |
-| **Association** (Destination → Source)     | korrespondansepart 1..* Korrespondansepart               | Registrering         |             |
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                                 |
-| ------------------------------------------------------------------------- |
-| self                                                                      |
-| https://rel.arkivverket.no/noark5/v5/api/metadata/korrespondanseparttype/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepart/     |
-
-Table: Attributter
-
-| **Navn**  | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
-|-----------|---------------|---------------|-----------|-----------|
-| systemID                      | Definisjon: Entydig identifikasjon av arkivenheten innenfor det arkivskapende organet. Dersom organet har flere arkivsystemer, skal altså systemID være gjennomgående entydig. Systemidentifikasjonen vil som oftest være en nummerisk kode uten noe logisk meningsinnhold. Identifikasjonen trenger ikke å være synlig for brukerne. Kilde: Registreres automatisk av systemet Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkivenhetens systemidentifikasjon. Dette gjelder også referanser fra en arkivdel til en annen, f.eks. mellom to arkivperioder som avleveres på forskjellig tidspunkt. I et arkivuttrekk skal systemID være entydig (unik). Dokumentobjekt har ingen systemidentifikasjon fordi enheten kan være duplisert i et arkivuttrekk dersom samme dokumentfil er knyttet til flere forskjellige registreringer. M001 | \[0..1\] | | SystemID |
-| korrespondanseparttype        | Definisjon: Type korrespondansepart . Kilde: Registreres automatisk knyttet til funksjonalitet i forbindelse med opprettelse av journalpost, kan også registreres  manuelt. Kommentarer: Korrespondansetype forekommer én gang innenfor objektet korrespondansepart, men denne kan forekomme flere ganger innenfor en journalpost. M087 | \[1..1\] | | Korrespondanseparttype|
-| virksomhetsspesifikkeMetadata | Definisjon: Et overordnet metadataelement som kan inneholde egendefinerte metadata. Disse metadataene må da være spesifisert i et eller flere XML-skjema. Kilde: (ingen). Kommentar: (ingen). M711 virksomhetsspesifikkeMetadata | \[0..1\] | | any |
-
-Table: Restriksjoner
-
-| **Navn**                              | **Merknad** |
-| ------------------------------------- | ----------- |
-| M001 systemID: Skal ikke kunne endres |             |
-
-#### KorrespondansepartEnhet
-
-*Type:* ***Class***
-
-*Arver:* ***Korrespondansepart***
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | KorrespondansepartEnhet                                  | Korrespondansepart     |             | 
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                                     |
-| ----------------------------------------------------------------------------- |
-| self                                                                          |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepartenhet/    |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-korrespondansepartenhet/ |
-
-Table: Attributter
-
-| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type**           |
-| ----------------------- | ----------- | ------------ | -------- | ------------------ |
-| enhetsidentifikator     |             | \[0..1\]     |          | Enhetsidentifikator|
-| navn                    |             | \[1..1\]     |          | string             |
-| forretningsadresse      |             | \[0..1\]     |          | EnkelAdresse       |
-| postadresse             |             | \[0..1\]     |          | EnkelAdresse       |
-| kontaktinformasjon      |             | \[0..1\]     |          | Kontaktinformasjon |
-| kontaktperson           |             | \[0..1\]     |          | string             |
-
-#### KorrespondansepartIntern
-
-*Type:* ***Class***
-
-*Arver:* ***Korrespondansepart***
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | KorrespondansepartIntern                                 | Korrespondansepart     |             |
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                                      |
-| ------------------------------------------------------------------------------ |
-| self                                                                           |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepartintern/    |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-korrespondansepartintern/ |
-
-Table: Attributter
-
-| **Navn**                        | **Merknad**                                   | **Multipl.** | **Kode** | **Type** |
-| ------------------------------- | --------------------------------------------- | ------------ | -------- | -------- |
-| administrativEnhet              |                                               | \[0..1\]     |          | string   |
-| referanseAdministrativEnhet     | referanse til AdministrativEnhet sin systemID | \[0..1\]     |          | SystemID |
-| saksbehandler                   |                                               | \[0..1\]     |          | string   |
-| referanseSaksbehandler          | referanse til Bruker sin systemID             | \[0..1\]     |          | SystemID |
-
-#### KorrespondansepartPerson
-
-*Type:* ***Class***
-
-*Arver:* ***Korrespondansepart***
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | KorrespondansepartPerson                                 | Korrespondansepart     |             |
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                                      |
-| ------------------------------------------------------------------------------ |
-| self                                                                           |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/korrespondansepartperson/    |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-korrespondansepartperson/ |
-
-Table: Attributter
-
-| **Navn**               | **Merknad** | **Multipl.** | **Kode** | **Type**           |
-| ---------------------- | ----------- | ------------ | -------- | ------------------ |
-| personidentifikator    |             | \[0..*\]     |          | Personidentifikator|
-| navn                   |             | \[1..1\]     |          | string             |
-| postadresse            |             | \[0..1\]     |          | EnkelAdresse       |
-| bostedsadresse         |             | \[0..1\]     |          | EnkelAdresse       |
-| kontaktinformasjon     |             | \[0..1\]     |          | Kontaktinformasjon |
 
 #### Presedens
 
@@ -3387,114 +3495,6 @@ Table: Restriksjoner
 | M012 sakssekvensnummer: Skal ikke kunne endres | |
 | M100 saksdato: Skal kunne endres manuelt inntil saksmappen avsluttes | |
 | M106 utlaantDato: Utlån skal også kunne registreres etter at en saksmappe er avsluttet, eller etter at dokumentene i en journalpost ble arkivert. | |
-
-#### Part
-
-*Type:* ***Class***
-
-*Arver:* 
-
-En eller flere virksomheter eller personer kan være knyttet til en
-mappe eller registrering som parter.
-
-Metadata for part skal kunne grupperes inn i metadata for mappe og
-registrering.  Part er valgfritt, og kan forekomme en eller flere
-ganger i tilknytning til en mappe og registrering.  Dersom det er mer
-enn én part, må metadataene grupperes sammen ved eksport og
-utveksling.
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | PartPerson                                           | Part               |             |
-| **Generalization** (Source → Destination)  | PartEnhet                                            | Part               |             |
-| **Association** (Destination → Source)     | part 0..* Part                                     | Mappe                |             |
-| **Association** (Destination → Source)     | part 0..* Part                                     | Registrering         |             |
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                    |
-| ------------------------------------------------------------ |
-| self                                                         |
-| https://rel.arkivverket.no/noark5/v5/api/metadata/partrolle/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-part/   |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/part/      |
-
-Table: Attributter
-
-| **Navn**  | **Merknad**   | **Multipl.**  | **Kode**  | **Type**  |
-|-----------|---------------|---------------|-----------|-----------|
-| systemID                      | Definisjon: Entydig identifikasjon av arkivenheten innenfor det arkivskapende organet. Dersom organet har flere arkivsystemer, skal altså systemID være gjennomgående entydig. Systemidentifikasjonen vil som oftest være en nummerisk kode uten noe logisk meningsinnhold. Identifikasjonen trenger ikke å være synlig for brukerne. Kilde: Registreres automatisk av systemet Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkivenhetens systemidentifikasjon. Dette gjelder også referanser fra en arkivdel til en annen, f.eks. mellom to arkivperioder som avleveres på forskjellig tidspunkt. I et arkivuttrekk skal systemID være entydig (unik). Dokumentobjekt har ingen systemidentifikasjon fordi enheten kan være duplisert i et arkivuttrekk dersom samme dokumentfil er knyttet til flere forskjellige registreringer. M001 | \[0..1\] | | SystemID |
-| partRolle                 | Definisjon: Angivelse av rollen til parten . Kilde: Registreres manuelt eller automatisk fra fagsystem. Kommentarer: (ingen). Betingelser: Her er det mange tenkelige roller avhengig av type sak, f.eks. Klient, Pårørende, Formynder, Advokat. M303 | \[1..1\] | | PartRolle |
-| virksomhetsspesifikkeMetadata |  | \[0..1\] | | any |
-
-Table: Restriksjoner
-
-| **Navn**                              | **Merknad** |
-| ------------------------------------- | ----------- |
-| M001 systemID: Skal ikke kunne endres |             |
-
-#### PartEnhet
-
-*Type:* ***Class***
-
-*Arver:* ***Part***
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | PartEnhet                                            | Part               |             |
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                       |
-| --------------------------------------------------------------- |
-| self                                                            |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-partenhet/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/partenhet/    |
-
-Table: Attributter
-
-| **Navn**                | **Merknad** | **Multipl.** | **Kode** | **Type**           |
-| ----------------------- | ----------- | ------------ | -------- | ------------------ |
-| enhetsidentifikator     |             | \[0..1\]     |          | Enhetsidentifikator|
-| navn                    |             | \[1..1\]     |          | string             |
-| forretningsadresse      |             | \[0..1\]     |          | EnkelAdresse       |
-| postadresse             |             | \[0..1\]     |          | EnkelAdresse       |
-| kontaktinformasjon      |             | \[0..1\]     |          | Kontaktinformasjon |
-| kontaktperson           |             | \[0..1\]     |          | string             |
-
-#### PartPerson
-
-*Type:* ***Class***
-
-*Arver:* ***Part***
-
-Table: Relasjoner
-
-| **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
-| ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Generalization** (Source → Destination)  | PartPerson                                           | Part               |             |
-
-Table: Relasjonsnøkler
-
-| **Verdi**                                                        |
-| ---------------------------------------------------------------- |
-| self                                                             |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-partperson/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/partperson/    |
-
-Table: Attributter
-
-| **Navn**               | **Merknad** | **Multipl.** | **Kode** | **Type**           |
-| ---------------------- | ----------- | ------------ | -------- | ------------------ |
-| personidentifikator    |             | \[0..*\]     |          | Personidentifikator|
-| navn                   |             | \[1..1\]     |          | string             |
-| postadresse            |             | \[0..1\]     |          | EnkelAdresse       |
-| bostedsadresse         |             | \[0..1\]     |          | EnkelAdresse       |
-| kontaktinformasjon     |             | \[0..1\]     |          | Kontaktinformasjon |
 
 ### Admin 
 

--- a/kapitler/media/uml-arkivstruktur-omfattende-forklart.puml
+++ b/kapitler/media/uml-arkivstruktur-omfattende-forklart.puml
@@ -56,7 +56,7 @@ Arkivstruktur.Klasse "+sekundaerklassifikasjon 0..*" <--o Sakarkiv.Saksmappe
 Arkivstruktur.Klasse "+klasse 0..*" o--> "+mappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
 Arkivstruktur.Mappe <|- MoeteOgUtvalgsbehandling.Moetemappe
-Arkivstruktur.Mappe *--> "+part 0..*" Sakarkiv.Part
+Arkivstruktur.Mappe *--> "+part 0..*" Arkivstruktur.Part
 Arkivstruktur.Mappe *-> "+merknad 0..*" Arkivstruktur.Merknad
 Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
 Arkivstruktur.Merknad "+merknad 0..*" <--* Arkivstruktur.Registrering
@@ -67,7 +67,7 @@ Arkivstruktur.Dokumentbeskrivelse "+dokumentbeskrivelse 1" o--> "+dokumentobjekt
 Arkivstruktur.Registrering <|-- Sakarkiv.Arkivnotat
 Arkivstruktur.Registrering <|-- Sakarkiv.Journalpost
 Arkivstruktur.Registrering <|-- MoeteOgUtvalgsbehandling.Moeteregistrering
-Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
-Arkivstruktur.Registrering *--> "+part 0..*" Sakarkiv.Part
+Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
+Arkivstruktur.Registrering *--> "+part 0..*" Arkivstruktur.Part
 Arkivstruktur.Dokumentobjekt *--> "+konvertering 0..*" Arkivstruktur.Konvertering
 @enduml

--- a/kapitler/media/uml-class-korrespondansepart.iuml
+++ b/kapitler/media/uml-class-korrespondansepart.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.Korrespondansepart {
+class Arkivstruktur.Korrespondansepart {
   +systemID : SystemID [0..1]
   +korrespondanseparttype : Korrespondanseparttype
   +virksomhetsspesifikkeMetadata : any [0..1]

--- a/kapitler/media/uml-class-korrespondansepartenhet.iuml
+++ b/kapitler/media/uml-class-korrespondansepartenhet.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.KorrespondansepartEnhet <Korrespondansepart> {
+class Arkivstruktur.KorrespondansepartEnhet <Korrespondansepart> {
   +enhetsidentifikator : Enhetsidentifikator [0..1]
   +navn : string
   +forretningsadresse : EnkelAdresse [0..1]

--- a/kapitler/media/uml-class-korrespondansepartintern.iuml
+++ b/kapitler/media/uml-class-korrespondansepartintern.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.KorrespondansepartIntern <Korrespondansepart> {
+class Arkivstruktur.KorrespondansepartIntern <Korrespondansepart> {
   +administrativEnhet : string [0..1]
   +referanseAdministrativEnhet : SystemID [0..1]
   +saksbehandler : string [0..1]

--- a/kapitler/media/uml-class-korrespondansepartperson.iuml
+++ b/kapitler/media/uml-class-korrespondansepartperson.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.KorrespondansepartPerson <Korrespondansepart> {
+class Arkivstruktur.KorrespondansepartPerson <Korrespondansepart> {
   +personidentifikator : Personidentifikator [0..*]
   +navn : string
   +postadresse : EnkelAdresse [0..1]

--- a/kapitler/media/uml-class-part.iuml
+++ b/kapitler/media/uml-class-part.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.Part {
+class Arkivstruktur.Part {
   +systemID : SystemID [0..1]
   +partRolle : PartRolle
   +virksomhetsspesifikkeMetadata : any [0..1]

--- a/kapitler/media/uml-class-partenhet.iuml
+++ b/kapitler/media/uml-class-partenhet.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.PartEnhet <Part> {
+class Arkivstruktur.PartEnhet <Part> {
   +enhetsidentifikator : Enhetsidentifikator [0..1]
   +navn : string
   +forretningsadresse : EnkelAdresse [0..1]

--- a/kapitler/media/uml-class-partperson.iuml
+++ b/kapitler/media/uml-class-partperson.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.PartPerson <Part> {
+class Arkivstruktur.PartPerson <Part> {
   +personidentifikator : Personidentifikator [0..*]
   +navn : string
   +postadresse : EnkelAdresse [0..1]

--- a/kapitler/media/uml-datatype-enkeladresse.iuml
+++ b/kapitler/media/uml-datatype-enkeladresse.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.EnkelAdresse <<dataType>> {
+class Arkivstruktur.EnkelAdresse <<dataType>> {
   +adresselinje1 : string [0..1]
   +adresselinje2 : string [0..1]
   +adresselinje3 : string [0..1]

--- a/kapitler/media/uml-datatype-kontaktinformasjon.iuml
+++ b/kapitler/media/uml-datatype-kontaktinformasjon.iuml
@@ -1,5 +1,5 @@
 @startuml
-class Sakarkiv.Kontaktinformasjon <<dataType>> {
+class Arkivstruktur.Kontaktinformasjon <<dataType>> {
   +epostadresse : string [0..1]
   +mobiltelefon : string [0..1]
   +telefon : string [0..1]

--- a/kapitler/media/uml-journalpost.puml
+++ b/kapitler/media/uml-journalpost.puml
@@ -13,7 +13,7 @@ skinparam nodesep 180
 
 Kodelister.FlytStatus <-[hidden]-- Sakarkiv.Dokumentflyt
 Sakarkiv.Dokumentflyt "+dokumentflyt 0..*" <--* Sakarkiv.Journalpost
-Sakarkiv.Korrespondansepart "+korrespondansepart 0..*" <--* Sakarkiv.Journalpost
+Arkivstruktur.Korrespondansepart "+korrespondansepart 0..*" <--* Sakarkiv.Journalpost
 Sakarkiv.Presedens "+presedens 0..*" <--o "+journalpost 0..*" Sakarkiv.Journalpost
 Sakarkiv.Journalpost *-> "+avskrivning 0..*" Sakarkiv.Avskrivning
 Sakarkiv.Journalpost <-[hidden]-- Kodelister.Journalposttype

--- a/kapitler/media/uml-klasse-avskrivning.puml
+++ b/kapitler/media/uml-klasse-avskrivning.puml
@@ -9,10 +9,10 @@ skinparam classAttributeIconSize 0
 !include kapitler/media/uml-class-avskrivning.iuml
 !include kapitler/media/uml-codelist-avskrivningsmaate.iuml
 
-Sakarkiv.Journalpost *-> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
-Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartPerson
-Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartEnhet
-Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartIntern
+Sakarkiv.Journalpost *-> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
+Arkivstruktur.Korrespondansepart <|-- Sakarkiv.KorrespondansepartPerson
+Arkivstruktur.Korrespondansepart <|-- Sakarkiv.KorrespondansepartEnhet
+Arkivstruktur.Korrespondansepart <|-- Sakarkiv.KorrespondansepartIntern
 Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
 Sakarkiv.Avskrivning <-[hidden]- Kodelister.Avskrivningsmaate
 @enduml

--- a/kapitler/media/uml-klasse-person-og-organisasjonsdata.puml
+++ b/kapitler/media/uml-klasse-person-og-organisasjonsdata.puml
@@ -6,32 +6,32 @@
 !include kapitler/media/uml-class-korrespondansepartperson.iuml
 !include kapitler/media/uml-class-korrespondansepartenhet.iuml
 
-Arkivstruktur.Registrering *- "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
-Arkivstruktur.Registrering *-- "+part 0..*" Sakarkiv.Part
-Sakarkiv.Korrespondansepart <-[hidden]- Kodelister.Korrespondanseparttype
-Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartPerson
-Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartEnhet
-Sakarkiv.Korrespondansepart <|-- Sakarkiv.KorrespondansepartIntern
+Arkivstruktur.Registrering *- "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
+Arkivstruktur.Registrering *-- "+part 0..*" Arkivstruktur.Part
+Arkivstruktur.Korrespondansepart <-[hidden]- Kodelister.Korrespondanseparttype
+Arkivstruktur.Korrespondansepart <|-- Sakarkiv.KorrespondansepartPerson
+Arkivstruktur.Korrespondansepart <|-- Sakarkiv.KorrespondansepartEnhet
+Arkivstruktur.Korrespondansepart <|-- Sakarkiv.KorrespondansepartIntern
 
 note "ISO liste" as isoliste
 note "fra posten.no" as fraposten
 class Kodelister.Land <<codelist>>
 class Kodelister.Postnummer <<codelist>>
-Sakarkiv.EnkelAdresse <-[hidden]- Kodelister.Land
+Arkivstruktur.EnkelAdresse <-[hidden]- Kodelister.Land
 Kodelister.Land .. isoliste
-Sakarkiv.EnkelAdresse <-[hidden]- Kodelister.Postnummer
+Arkivstruktur.EnkelAdresse <-[hidden]- Kodelister.Postnummer
 Kodelister.Postnummer .. fraposten
 
 !include kapitler/media/uml-class-administrativenhet.iuml
 !include kapitler/media/uml-class-bruker.iuml
 
-Sakarkiv.KorrespondansepartIntern <-[hidden]-- Admin.AdministrativEnhet
+Arkivstruktur.KorrespondansepartIntern <-[hidden]-- Admin.AdministrativEnhet
 Admin.AdministrativEnhet "+enhet 0..*" <--> "+bruker 0..*" Admin.Bruker
 
 !include kapitler/media/uml-datatype-enkeladresse.iuml
 
-Sakarkiv.KorrespondansepartPerson <-[hidden]-- Sakarkiv.EnkelAdresse
-Sakarkiv.KorrespondansepartEnhet <-[hidden]-- Sakarkiv.EnkelAdresse
+Arkivstruktur.KorrespondansepartPerson <-[hidden]-- Arkivstruktur.EnkelAdresse
+Arkivstruktur.KorrespondansepartEnhet <-[hidden]-- Arkivstruktur.EnkelAdresse
 
 !include kapitler/media/uml-datatype-kontaktinformasjon.iuml
 !include kapitler/media/uml-class-part.iuml
@@ -43,10 +43,10 @@ class Sakarkiv.Journalpost <Registrering>
 Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
 Arkivstruktur.Registrering <|-- Sakarkiv.Journalpost
 
-Arkivstruktur.Mappe *-- "+part 0..*" Sakarkiv.Part
-Sakarkiv.Part <|-- Sakarkiv.PartPerson
-Sakarkiv.Part <|-- Sakarkiv.PartEnhet
-Sakarkiv.PartPerson <-[hidden]- Sakarkiv.Kontaktinformasjon
-Sakarkiv.PartEnhet <-[hidden]- Sakarkiv.Kontaktinformasjon
+Arkivstruktur.Mappe *-- "+part 0..*" Arkivstruktur.Part
+Arkivstruktur.Part <|-- Sakarkiv.PartPerson
+Arkivstruktur.Part <|-- Arkivstruktur.PartEnhet
+Arkivstruktur.PartPerson <-[hidden]- Arkivstruktur.Kontaktinformasjon
+Arkivstruktur.PartEnhet <-[hidden]- Arkivstruktur.Kontaktinformasjon
 
 @enduml

--- a/kapitler/media/uml-klasse-saksbehandling.puml
+++ b/kapitler/media/uml-klasse-saksbehandling.puml
@@ -13,12 +13,12 @@ skinparam nodesep 180
 !include kapitler/media/uml-codelist-avskrivningsmaate.iuml
 !include kapitler/media/uml-class-dokumentflyt.iuml
 
-Sakarkiv.Part "+part 0..*" <--* Sakarkiv.Saksmappe
-Kodelister.PartRolle <-[hidden]--  Sakarkiv.Part
+Arkivstruktur.Part "+part 0..*" <--* Sakarkiv.Saksmappe
+Kodelister.PartRolle <-[hidden]--  Arkivstruktur.Part
 Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
 Sakarkiv.Journalpost "+journalpost 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
-Sakarkiv.Journalpost *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
-Kodelister.Korrespondanseparttype <-[hidden]-- Sakarkiv.Korrespondansepart
+Sakarkiv.Journalpost *--> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
+Kodelister.Korrespondanseparttype <-[hidden]-- Arkivstruktur.Korrespondansepart
 Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
 Kodelister.Avskrivningsmaate  <-[hidden]- Sakarkiv.Avskrivning
 Sakarkiv.Journalpost *-> "+dokumentflyt 0..*" Sakarkiv.Dokumentflyt

--- a/kapitler/media/uml-komposisjon-brukt-med-klasser.puml
+++ b/kapitler/media/uml-komposisjon-brukt-med-klasser.puml
@@ -2,5 +2,5 @@
 skinparam classAttributeIconSize 0
 'FIXME dropped caption "class Fig05_Komposisjon"
 !include kapitler/media/uml-class-registrering.iuml
-Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
 @enduml

--- a/kapitler/media/uml-sakarkiv-entiteter.puml
+++ b/kapitler/media/uml-sakarkiv-entiteter.puml
@@ -13,12 +13,12 @@ Arkivstruktur.Mappe <|-- Sakarkiv.Saksmappe
 
 Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Registrering
 Arkivstruktur.Mappe "+overmappe 0..1" o--> "+undermappe 0..*" Arkivstruktur.Mappe
-Arkivstruktur.Mappe *-> "+part 0..*" Sakarkiv.Part
-Arkivstruktur.Registrering *-> "+part 0..*" Sakarkiv.Part
+Arkivstruktur.Mappe *-> "+part 0..*" Arkivstruktur.Part
+Arkivstruktur.Registrering *-> "+part 0..*" Arkivstruktur.Part
 Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*\n" Sakarkiv.Presedens
 Sakarkiv.Journalpost "+journalpost 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
 
-Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Sakarkiv.Korrespondansepart
+Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
 Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
 Sakarkiv.Dokumentflyt "+dokumentflyt 0..*" <--* Sakarkiv.Journalpost
 Sakarkiv.Dokumentflyt "+dokumentflyt 0..*" <--* Sakarkiv.Arkivnotat

--- a/kapitler/media/uml-saksmappe.puml
+++ b/kapitler/media/uml-saksmappe.puml
@@ -9,6 +9,6 @@ class Arkivstruktur.Klasse <Arkivenhet>
 Arkivstruktur.Klasse "\n\n+sekundaerklassifikasjon 0..*"  <--o Sakarkiv.Saksmappe
 Arkivstruktur.Klasse "+overklasse 0..1" o--> "\n+underklasse 0..*" Arkivstruktur.Klasse
 Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*" Sakarkiv.Presedens
-Sakarkiv.Saksmappe *--> "+part 0..*" Sakarkiv.Part
+Sakarkiv.Saksmappe *--> "+part 0..*" Arkivstruktur.Part
 
 @enduml


### PR DESCRIPTION
Flyttes fra Sakarkiv til Arkivstruktur for å unngå avhengighet fra pakken
Arkivstruktur til pakken Sakarkiv.  Endringen er i tråd med XSD-endring
fra Arkitektum.