### PR TITLE
Korriger relasjon mellom Registrering og Korrespondansepart

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -1136,7 +1136,7 @@ Table: Relasjoner
 | **Generalization** (Source → Destination)  | KorrespondansepartEnhet                                  | Korrespondansepart     |             |
 | **Generalization** (Source → Destination)  | KorrespondansepartPerson                                 | Korrespondansepart     |             |
 | **Generalization** (Source → Destination)  | KorrespondansepartIntern                                 | Korrespondansepart     |             |
-| **Association** (Destination → Source)     | korrespondansepart 1..* Korrespondansepart               | Registrering         |             |
+| **Association** (Destination → Source)     | korrespondansepart 0..* Korrespondansepart               | Registrering         |             |
 
 Table: Relasjonsnøkler
 


### PR DESCRIPTION
Relasjonen skal være valgfri (0..*), og det er korrekt i beskrivelsen
av Mappe, men feil i beskrivelsen av Korrespondansepart.