### PR TITLE
Korriger ene siden av relasjonen Bruker - AdministrativEnhet.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -3575,7 +3575,7 @@ Table: Relasjoner
 
 | **Relasjon**                             | **Kilde**                                                | **Mål**                | **Merknad** |
 | ---------------------------------------- | -------------------------------------------------------- | ---------------------- | ----------- |
-| **Association** (Bi-Directional)         | bruker 0..* Bruker                                       | enhet 0..* AdministrativEnhet |      |
+| **Association** (Bi-Directional)         | bruker 0..* Bruker                                       | administrativenhet 0..* AdministrativEnhet |      |
 
 Table: Relasjonsnøkler
 


### PR DESCRIPTION
En av de to beskrivelsene av relasjonen mellom Bruker og
AdministrativEnhet brukte navnet 'enhet', og den andre bruker
'administrativenhet'.  Disse skal være like, så jeg gikk for det
navnet som stemmer overens med relasjonsnøkkelen
https://rel.arkivverket.no/noark5/v5/api/admin/administrativenhet/.