### PR TITLE
Ta med Arkivenhet i UML-diagram som forklarer LoggingOgSporing

### DIFF
--- a/kapitler/media/uml-endringslogg.puml
+++ b/kapitler/media/uml-endringslogg.puml
@@ -1,7 +1,10 @@
 @startuml
 skinparam classAttributeIconSize 0
+!include kapitler/media/uml-class-arkivenhet.iuml
 !include kapitler/media/uml-class-endringslogg.iuml
 !include kapitler/media/uml-class-hendelseslogg.iuml
 !include kapitler/media/uml-codelist-hendelsetype.iuml
 LoggingOgSporing.Endringslogg <|-- LoggingOgSporing.Hendelseslogg
+Arkivstruktur.Arkivenhet "0..1" o- "logg 0..*" LoggingOgSporing.Hendelseslogg
+LoggingOgSporing.Hendelseslogg -[hidden]- Kodelister.Hendelsetype
 @enduml


### PR DESCRIPTION
Vis hvordan Hendelseslogg har en relasjon til Arkivenhet, og knytt
Hendelsetype og Hendelseslogg sammen i UML-diagrammet.