### PR TITLE
Dokumentbeskrivelse skal lenke til Part

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -629,6 +629,7 @@ Table: Relasjoner
 | **Generalization** (Source → Destination)  | Dokumentbeskrivelse                                      | Arkivenhet             |             |
 | **Association** (Source → Destination)     | Dokumentbeskrivelse                                      | merknad 0..* Merknad   |             |
 | **Aggregation** (Bi-Directional)           | dokumentobjekt 0..* Dokumentobjekt                       | dokumentbeskrivelse 1 Dokumentbeskrivelse | |
+| **Association** (Source → Destination)     | Dokumentbeskrivelse                                      | part 0..* Part         |             |
 
 Table: Relasjonsnøkler
 
@@ -1624,6 +1625,7 @@ Table: Relasjoner
 | **Generalization** (Source → Destination)  | PartEnhet                                            | Part               |             |
 | **Association** (Destination → Source)     | part 0..* Part                                     | Mappe                |             |
 | **Association** (Destination → Source)     | part 0..* Part                                     | Registrering         |             |
+| **Association** (Source → Destination)     | Dokumentbeskrivelse                                | part 0..* Part       |             |
 
 Table: Relasjonsnøkler
 

--- a/kapitler/media/uml-arkivstruktur-omfattende-forklart.puml
+++ b/kapitler/media/uml-arkivstruktur-omfattende-forklart.puml
@@ -48,5 +48,6 @@ Arkivstruktur.Registrering <|-- Sakarkiv.Arkivnotat
 Arkivstruktur.Registrering <|-- Sakarkiv.Journalpost
 Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
 Arkivstruktur.Registrering *--> "+part 0..*" Arkivstruktur.Part
+Arkivstruktur.Dokumentbeskrivelse *--> "+part 0..*" Arkivstruktur.Part
 Arkivstruktur.Dokumentobjekt *--> "+konvertering 0..*" Arkivstruktur.Konvertering
 @enduml

--- a/kapitler/media/uml-klasse-person-og-organisasjonsdata.puml
+++ b/kapitler/media/uml-klasse-person-og-organisasjonsdata.puml
@@ -1,5 +1,9 @@
 @startuml
 
+class Arkivstruktur.Mappe <Arkivenhet>
+class Arkivstruktur.Registrering <Arkivenhet>
+class Arkivstruktur.Dokumentbeskrivelse <Arkivenhet>
+
 !include kapitler/media/uml-codelist-korrespondanseparttype.iuml
 !include kapitler/media/uml-class-korrespondansepart.iuml
 !include kapitler/media/uml-class-korrespondansepartintern.iuml
@@ -43,5 +47,7 @@ Arkivstruktur.Part <|-- Arkivstruktur.PartPerson
 Arkivstruktur.Part <|-- Arkivstruktur.PartEnhet
 Arkivstruktur.PartPerson <-[hidden]- Arkivstruktur.Kontaktinformasjon
 Arkivstruktur.PartEnhet <-[hidden]- Arkivstruktur.Kontaktinformasjon
+
+Arkivstruktur.Dokumentbeskrivelse *-- "+part 0..*" Arkivstruktur.Part
 
 @enduml

--- a/kapitler/media/uml-sakarkiv-entiteter.puml
+++ b/kapitler/media/uml-sakarkiv-entiteter.puml
@@ -16,10 +16,11 @@ Arkivstruktur.Mappe "+mappe 0..1" o--> "+registrering 0..*" Arkivstruktur.Regist
 Arkivstruktur.Mappe "+overmappe 0..1" o--> "+undermappe 0..*" Arkivstruktur.Mappe
 Arkivstruktur.Mappe *--> "+part 0..*" Arkivstruktur.Part
 Arkivstruktur.Registrering *--> "+part 0..*" Arkivstruktur.Part
+Arkivstruktur.Dokumentbeskrivelse *--> "+part 0..*" Arkivstruktur.Part
 Sakarkiv.Saksmappe "+sak 0..*" o--> "+presedens 0..*\n" Sakarkiv.Presedens
 Sakarkiv.Presedens "+presedens 0..*" <--o  "+journalpost 0..*" Sakarkiv.Journalpost
 
-Arkivstruktur.Registrering *--> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
+Arkivstruktur.Registrering *-> "+korrespondansepart 0..*" Arkivstruktur.Korrespondansepart
 Sakarkiv.Journalpost *--> "+avskrivning 0..*" Sakarkiv.Avskrivning
 Sakarkiv.Journalpost *--> "+dokumentflyt 0..*" Sakarkiv.Dokumentflyt
 Sakarkiv.Arkivnotat *--> "+dokumentflyt 0..*" Sakarkiv.Dokumentflyt


### PR DESCRIPTION
I overgangen til Noark 5.5 så ble relasjonen mellom Dokumentbeskrivelse
og Part avglemt.  Denne relasjonen er tilstede i arkivstruktur.xsd for
5.5, og forklaringen i https://github.com/arkivverket/schemas/pull/11 gjør
det klart at den skal være med også her.