### PR TITLE
Korriger relasjonsnøkler for part.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -548,7 +548,8 @@ Table: Relasjonsnøkler
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-mappe/               |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-matrikkel/           |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-merknad/             |
-| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-part/                |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-partenhet/           |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-partperson/          |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-plan/                |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-posisjon/            |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-registrering/        |
@@ -1485,7 +1486,8 @@ Table: Relasjonsnøkler
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-mappe/              |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-matrikkel/          |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-merknad/            |
-| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-part/               |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-partenhet/          |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-partperson/         |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-plan/               |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-posisjon/           |
 | https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-registrering/       |
@@ -1630,9 +1632,8 @@ Table: Relasjonsnøkler
 | **Verdi**                                                    |
 | ------------------------------------------------------------ |
 | self                                                         |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/part/ |
 | https://rel.arkivverket.no/noark5/v5/api/metadata/partrolle/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-part/   |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/part/      |
 
 Table: Attributter
 
@@ -1665,8 +1666,8 @@ Table: Relasjonsnøkler
 | **Verdi**                                                       |
 | --------------------------------------------------------------- |
 | self                                                            |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-partenhet/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/partenhet/    |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-partenhet/ |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/partenhet/    |
 
 Table: Attributter
 
@@ -1696,8 +1697,8 @@ Table: Relasjonsnøkler
 | **Verdi**                                                        |
 | ---------------------------------------------------------------- |
 | self                                                             |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/ny-partperson/ |
-| https://rel.arkivverket.no/noark5/v5/api/sakarkiv/partperson/    |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-partperson/ |
+| https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/partperson/    |
 
 Table: Attributter
 


### PR DESCRIPTION
Part hører under arkivstruktur nå, etter at den ble overført til mappe og
registrering , og dermed skal relasjonsnøkler endres til å reflektere dette.

I tillegg skal det ikke eksistere en ny-part (den entiteten er virtuell og
kan ikke instansieres), men derimot individuelle ny-enhet og ny-partperson.