### PR TITLE
Legg til en ekstra SHA-256-referanse

### DIFF
--- a/kapitler/02-normative_referanser.md
+++ b/kapitler/02-normative_referanser.md
@@ -16,7 +16,9 @@ Webtjenester med REST/HATEOAS -
 https://tools.ietf.org/html/draft-kelly-json-hal-08
 
 Sjekksumalgoritmen SHA-256 er definert i IETF RFC 4634 -
-https://tools.ietf.org/html/rfc4634
+https://tools.ietf.org/html/rfc4634 og Federal Information Processing
+Standards Publication Secure Hash Standard (SHS) (FIPS PUB 180-3) -
+http://csrc.nist.gov/publications/fips/fips180-3/fips180-3_final.pdf .
 
 Bruken av PATCH for å oppdatere JSON er beskrevet i [IETF RFC
 7396 - JSON Merge Patch](https://tools.ietf.org/html/rfc7396).


### PR DESCRIPTION
Rundskriv om krav om sjekksummer ved overføring av arkivuttrekk til Riksarkivet
(2011/23213HANBER datert 2012-03-08) henviser til FIPS PUB 130-3 i stedet for
RFC 4634.  Begge dokumenterer samme algoritme, men det virker som en god ide å
dokumentere at tjenestegrensesnittet er i tråd med rundskrivet.