### PR TITLE
Fix typo in example JSON for a 404 error.

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.md
+++ b/kapitler/06-konsepter_og_prinsipper.md
@@ -1388,7 +1388,7 @@ verdi av beskrivelse er ikke standardisert:
 ```
 {
   "feil": {
-    "kode": 404
+    "kode": 404,
     "beskrivelse": "Not Found: arkivstruktur/arkivdel/9d5bda48-52b5-11e9-abc0-002354090596/"
   }
 }


### PR DESCRIPTION
Add missing comma to get valid JSON.