### PR TITLE
Endret datatype for verdier i Matrikkel fra 'string' til 'integer'.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -1954,8 +1954,8 @@ Table: Attributter
 | kommunenummer       |             | \[1..1\]     |          | string          |
 | gaardsnummer        |             | \[1..1\]     |          | integer         |
 | bruksnummer         |             | \[1..1\]     |          | integer         |
-| festenummer         |             | \[0..1\]     |          | string          |
-| seksjonsnummer      |             | \[0..1\]     |          | string          |
+| festenummer         |             | \[0..1\]     |          | integer         |
+| seksjonsnummer      |             | \[0..1\]     |          | integer         |
 
 ##### Personidentifikator
 


### PR DESCRIPTION
I følge kartverkets SOSI-standard del 2, tilgjengelig fra
<URL: https://www.kartverket.no/geodataarbeid/standarder/sosi/sosi-standarden-del-2/ >,
så består et Matrikkelnummer av en kommunereferanse og fire integer, henholdsvis
gårdsnummer, bruksnummer, festenummer og seksjonsnummer.

I tjenestegrensesnittet er det ved en inkurie ført opp datatype 'string' på
festenummer og seksjonsnummer, og dette endres til 'integer'.