### PR TITLE
Make Klasse.gradering attribute exist to match N5v5.5 arkivstruktur.xsd.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -979,6 +979,7 @@ Table: Attributter
 | referanseAvsluttetAv  |               | \[0..1\]      |           | SystemID |
 | skjerming             |               | \[0..1\]      |           | Skjerming |
 | kassasjon             |               | \[0..1\]      |           | Kassasjon |
+| gradering             |               | \[0..1\]      |           | Gradering |
 
 Table: Restriksjoner
 


### PR DESCRIPTION
In the official XSD for Noark 5 version 5.5, the class type include
'gradering'.  This is missing in the API spesification, so I guess it
should be added to stay compatible with the XSD.