### PR TITLE
Rename obsolete .../sakspartrolle/ relation key in text.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -2186,7 +2186,7 @@ støtter Sakarkiv-pakken:
 | https://rel.arkivverket.no/noark5/v5/api/metadata/land/                               |
 | https://rel.arkivverket.no/noark5/v5/api/metadata/postnummer/                         |
 | https://rel.arkivverket.no/noark5/v5/api/metadata/presedensstatus/                    |
-| https://rel.arkivverket.no/noark5/v5/api/metadata/sakspartrolle/                      |
+| https://rel.arkivverket.no/noark5/v5/api/metadata/partrolle/                          |
 | https://rel.arkivverket.no/noark5/v5/api/metadata/saksstatus/                         |
 
 Følgende relasjonsnøkler skal listes opp fra en implementasjon som


### PR DESCRIPTION
When updating the specification to version 5.5, the 'sakspartrolle'
metadata codelist changed to 'partrolle', but one relation key
was left behind.  This change remove the now obsolete relation
key.