### PR TITLE
Mer fornuftige kodeverdier for Hendelsetype.

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.md
+++ b/kapitler/07-tjenester_og_informasjonsmodell.md
@@ -2550,6 +2550,10 @@ Table: Attributter
 
 *Arver:* 
 
+Åpen kodeliste
+
+Definisjon: Hva slags type hendelse som er logget.
+
 Table: Relasjonsnøkler
 
 | **Verdi**                                                       |
@@ -2560,10 +2564,10 @@ Table: Attributter
 
 | **Kodenavn**        | **Merknad** | **Multipl.** | **Kode** | **Type** |
 | ------------------- | ----------- | ------------ | -------- | -------- |
-| Endringslogg        |             |              |          |          |
-| Søknad mottatt      |             |              |          |          |
-| Søknad komplett     |             |              |          |          |
-| Vedtak              |             |              |          |          |
+| Opprettet           |             |              | C        |          |
+| Lest                |             |              | R        |          |
+| Endret              |             |              | U        |          |
+| Slettet             |             |              | D        |          |
 
 #### Journalposttype
 


### PR DESCRIPTION
Bruk klassiste CRUD-koder, i stedet for Endringslogg, Søknad mottatt, Søknad komplett og Vedtak.

Gjør det klart at dette er en åpen kodeliste.