### PR TITLE
Link to Unicode lists of Control and Space Separator characters

### DIFF
--- a/kapitler/12-vedlegg_5_-_usynlige_tegn.rst
+++ b/kapitler/12-vedlegg_5_-_usynlige_tegn.rst
@@ -2,10 +2,11 @@ Usynlige tegn
 =============
 
 I denne versjonen av tjenestegrensesnitt-spesifikasjonen anses
-følgende tegn hentet fra Unicode i kategoriene «Space Separator» og
-«Control» som usynlige tegn. Fremtidige versjoner av spesifikasjonen
-vil oppdatere listen med tegn hvis Unicode legger til flere tegn i
-disse kategoriene.
+følgende tegn hentet fra Unicode i kategoriene
+«`Space Separator <https://codepoints.net/search?gc=Zs>`__» og
+«`Control <https://codepoints.net/search?gc=Cc>`__» som usynlige
+tegn. Fremtidige versjoner av spesifikasjonen vil oppdatere listen med
+tegn hvis Unicode legger til flere tegn i disse kategoriene.
 
 .. list-table:: Usynlige tegn
    :widths: 1 3


### PR DESCRIPTION
This make it easier in the future to check if new characters have been added
to the list.  It also make the standard text more dependent on
an external source, which can change at any time.  It was the
best source I could find listing characters in the classes in question.