### PR TITLE
Endret forkomst fra 0..* til 1..* for Skjerming.SkjermingMetadata

### DIFF
--- a/kapitler/07-tjenester_og_informasjonsmodell.rst
+++ b/kapitler/07-tjenester_og_informasjonsmodell.rst
@@ -3988,7 +3988,7 @@ den enkelte mappe, registrering eller det enkelte dokument. (Se Noark
      og journalpost.  Ved midlertidig skjerming skal alle metadata
      ovenfor skjermes, må bare brukes inntil skjermingsbehovet er
      vurdert. M502
-   - [0..\*]
+   - [1..\*]
    -
    - SkjermingMetadata
  * - skjermingDokument

--- a/kapitler/media/uml-complete.puml
+++ b/kapitler/media/uml-complete.puml
@@ -350,7 +350,7 @@ class Arkivstruktur.Registrering <Arkivenhet> {
 class Arkivstruktur.Skjerming <<dataType>> {
   +tilgangsrestriksjon : Tilgangsrestriksjon
   +skjermingshjemmel : string
-  +skjermingMetadata : SkjermingMetadata [0..*]
+  +skjermingMetadata : SkjermingMetadata [1..*]
   +skjermingDokument : SkjermingDokument [0..1]
   +skjermingsvarighet : integer [0..1]
   +skjermingOpphoererDato : datetime [0..1]

--- a/kapitler/media/uml-datatype-skjerming.iuml
+++ b/kapitler/media/uml-datatype-skjerming.iuml
@@ -2,7 +2,7 @@
 class Arkivstruktur.Skjerming <<dataType>> {
   +tilgangsrestriksjon : Tilgangsrestriksjon
   +skjermingshjemmel : string
-  +skjermingMetadata : SkjermingMetadata [0..*]
+  +skjermingMetadata : SkjermingMetadata [1..*]
   +skjermingDokument : SkjermingDokument [0..1]
   +skjermingsvarighet : integer [0..1]
   +skjermingOpphoererDato : datetime [0..1]

--- a/kapitler/media/uml-datatype-skjerming.puml
+++ b/kapitler/media/uml-datatype-skjerming.puml
@@ -4,7 +4,7 @@ hide circle
 class Arkivstruktur.Skjerming <<dataType>> {
   +tilgangsrestriksjon : Tilgangsrestriksjon
   +skjermingshjemmel : string
-  +skjermingMetadata : SkjermingMetadata [0..*]
+  +skjermingMetadata : SkjermingMetadata [1..*]
   +skjermingDokument : SkjermingDokument [0..1]
   +skjermingsvarighet : integer [0..1]
   +skjermingOpphoererDato : datetime [0..1]


### PR DESCRIPTION
Dette bringer API-definisjon på linje med beskrivelse i Noark 5 og XSD.

Fixes #277.