### PR TITLE
Use oData v4 DateTime filter examples

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.rst
+++ b/kapitler/06-konsepter_og_prinsipper.rst
@@ -283,7 +283,7 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 ..
 
-   /api/sakarkiv/saksmappe?$filter=saksdato gt DateTime'2017-02-15'
+   /api/sakarkiv/saksmappe?$filter=saksdato gt 2017-02-15
 
 *Mindre enn*
 
@@ -291,7 +291,7 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 **Eksempel:**
 
-   /api/sakarkiv/saksmappe?$filter=saksdato lt DateTime'2017-02-15'
+   /api/sakarkiv/saksmappe?$filter=saksdato lt 2017-02-15
 
 *Større enn eller lik*
 
@@ -299,7 +299,7 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 **Eksempel:**
 
-   /api/sakarkiv/saksmappe?$filter=saksdato ge DateTime'2017-02-15'
+   /api/sakarkiv/saksmappe?$filter=saksdato ge 2017-02-15
 
 *Mindre enn eller lik*
 
@@ -307,7 +307,7 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 **Eksempel:**
 
-   /api/sakarkiv/saksmappe?$filter=saksdato le DateTime'2017-02-15'
+   /api/sakarkiv/saksmappe?$filter=saksdato le 2017-02-15
 
 *Og*
 
@@ -315,7 +315,7 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 **Eksempel:**
 
-   /api/sakarkiv/saksmappe/?$filter=saksdato gt DateTime'2017-02-10' and saksdato lt DateTime'2017-02-12'
+   /api/sakarkiv/saksmappe/?$filter=saksdato gt 2017-02-10 and saksdato lt 2017-02-12
 
 *Eller*
 


### PR DESCRIPTION
Casting DateTime literals has only been necessary in OData v2 whereas the specification explicitly refers to the oData v4.01 filter syntax. Since oData v4 now treats dates and datetimes as regular primitive literals (as documented in the link below), the examples needed to be updated.

https://docs.oasis-open.org/odata/odata/v4.0/cos01/part2-url-conventions/odata-v4.0-cos01-part2-url-conventions.html#_Toc371343071