### PR TITLE
Fix examples of the OData v4 substring function

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.rst
+++ b/kapitler/06-konsepter_og_prinsipper.rst
@@ -267,11 +267,11 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 *Inneholder*
 
-**Syntaks:** substringof(‘tekst’, feltnavn)
+**Syntaks:** substring(feltnavn, 1, 5) eq 'tekst'
 
 **Eksempel:**
 
-   /api/arkivstruktur/mappe/?$filter=substringof('test', tittel)
+   /api/arkivstruktur/mappe/?$filter=substring(tittel, 3, 4) eq 'test'
 
 *Større enn*
 
@@ -329,7 +329,7 @@ Flere filtre kan kombineres med operatorene **and** og **or**.
 
 *De to første mappene med test i tittelen*
 
-   /api/arkivstruktur/mappe/?$top=2&$filter=substringof('test',tittel)
+   /api/arkivstruktur/mappe/?$top=2&$filter=substring(tittel, 3, 4) eq 'test'
 
 *Mapper med graderingskode B*
 


### PR DESCRIPTION
The examples previously used substringof which is a OData v2 concept only.