### PR TITLE
Endre opplastingsprosedyre til å unngå ufullstendige dokumentobjekt-instanser

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.rst
+++ b/kapitler/06-konsepter_og_prinsipper.rst
@@ -1344,10 +1344,9 @@ resultatkoden 406, ikke resultatkode 200.
 
 **Opplasting**
 
-Opplasting av dokumentfiler kan enten gjøres fra dokumentbeskrivelse
-eller dokumentobjekt.  Resultatet fra en vellykket opplasting
-returnerer JSON for det nyopprettede eller oppdaterte
-dokumentobjektet.
+Opplasting av dokumentfiler skal støttes fra både dokumentbeskrivelse
+og dokumentobjekt.  Resultatet fra en vellykket opplasting returnerer
+JSON for det nyopprettede eller oppdaterte dokumentobjektet.
 
 Eksempel på oppretting fra dokumentbeskrivelse::
 
@@ -1397,25 +1396,25 @@ dokumentobjekt-instansen opprettes automatisk ved filopplasting, med
 mindre API-tjenesten kjenner igjen filinnholdet som et av de godkjente
 arkivformatene.
 
-Et dokumentobjekt også kan opprettes før opplasting når en laster opp
-fil via dokumentobjekcts opplastingsrelasjon.  Hvis noen av feltene
-«format», «mimeType», «filnavn», «sjekksum», «sjekksumAlgoritme» og
-«filstoerrelse» er fylt inn ved opprettelsen skal tjeneren verifisere
-at verdiene i de angitte feltene stemmer når den komplette filen er
-lastet opp. Tjeneren sjekker ved opplasting for felt som er
-forhåndsutfylt også at mimeType er identisk med Content-Type,
-filstoerrelse er identisk med Content-Length (for komplett POST) eller
-X-Upload-Content-Length (for overføring i bolker med PUT) og at
-sjekksum stemmer overens med den overførte filen. Hvis tjeneren etter
-opplasting ser at noen av verdiene avledet fra opplastet fil ikke
-stemmer overens med verdiene i dokumentobjekt-instansen, så returneres
-statuskode 400 Bad Request. Hvis den opplastede filen har et format
-tjeneren ikke kjenner igjen, så settes formatkoden til 'av/0'. Når
-filopplasting er fullført setter tjeneren de feltene i dokumentobjekt
-som ikke var satt ved oppretting av dokumentobjekt-instansen, det vil
-si utleder «format», «mimeType», «filnavn», «sjekksum», og
-«filstoerrelse» basert på filens innhold samt, samt gir
-«sjekksumAlgoritme» aktuell verdi.
+Ved opplasting fra dokumentobjekt må dokumentobjektet opprettes før en
+laster opp fil via dokumentobjekcts opplastingsrelasjon.  Hvis noen av
+feltene «format», «mimeType», «filnavn», «sjekksum»,
+«sjekksumAlgoritme» og «filstoerrelse» er fylt inn ved opprettelsen
+skal tjeneren verifisere at verdiene i de angitte feltene stemmer når
+den komplette filen er lastet opp. Tjeneren sjekker ved opplasting for
+felt som er forhåndsutfylt også at mimeType er identisk med
+Content-Type, filstoerrelse er identisk med Content-Length (for
+komplett POST) eller X-Upload-Content-Length (for overføring i bolker
+med PUT) og at sjekksum stemmer overens med den overførte filen. Hvis
+tjeneren etter opplasting ser at noen av verdiene avledet fra
+opplastet fil ikke stemmer overens med verdiene i
+dokumentobjekt-instansen, så returneres statuskode 400 Bad
+Request. Hvis den opplastede filen har et format tjeneren ikke kjenner
+igjen, så settes formatkoden til 'av/0'. Når filopplasting er fullført
+setter tjeneren de feltene i dokumentobjekt som ikke var satt ved
+oppretting av dokumentobjekt-instansen, det vil si utleder «format»,
+«mimeType», «filnavn», «sjekksum», og «filstoerrelse» basert på filens
+innhold samt, samt gir «sjekksumAlgoritme» aktuell verdi.
 
 **Overføre små filer**
 

--- a/kapitler/06-konsepter_og_prinsipper.rst
+++ b/kapitler/06-konsepter_og_prinsipper.rst
@@ -1392,6 +1392,11 @@ Eksempel på oppretting fra dokumentbeskrivelse::
         }
     }
 
+Verdien for «variantformat» settes til «Produksjonsformat» når
+dokumentobjekt-instansen opprettes automatisk ved filopplasting, med
+mindre API-tjenesten kjenner igjen filinnholdet som et av de godkjente
+arkivformatene.
+
 Et dokumentobjekt også kan opprettes før opplasting når en laster opp
 fil via dokumentobjekcts opplastingsrelasjon.  Hvis noen av feltene
 «format», «mimeType», «filnavn», «sjekksum», «sjekksumAlgoritme» og

--- a/kapitler/07-tjenester_og_informasjonsmodell.rst
+++ b/kapitler/07-tjenester_og_informasjonsmodell.rst
@@ -1488,6 +1488,13 @@ begrepet enkeltdokument. En registrering som dokumenterer en
 transaksjon, vil vanligvis bestå av bare ett enkeltdokument.
 Dokumentbeskrivelsen inneholder altså metadata for enkeltdokumenter.
 
+Ved opplasting av fil ved bruk av relasjonen
+https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/fil/ , så vil
+det automatisk opprettes et dokumentobjekt med forvalgte verdier
+avledet fra den opplastede filen, se kapittel 6.  JSON for dette
+objektet returneres som resultat av opplastingen, på eneste
+forespørslen for små filer og på siste forespørsel for store filer.
+
 .. list-table:: Relasjoner
    :widths: 4 5 4 4
    :header-rows: 1
@@ -1524,6 +1531,7 @@ Dokumentbeskrivelsen inneholder altså metadata for enkeltdokumenter.
  * - self
  * - https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/dokumentbeskrivelse/
  * - https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/dokumentobjekt/
+ * - https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/fil/
  * - https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/merknad/
  * - https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-dokumentbeskrivelse/
  * - https://rel.arkivverket.no/noark5/v5/api/arkivstruktur/ny-dokumentobjekt/


### PR DESCRIPTION
Tillat opplasting direkte fra dokumentbeskrivelse og dokumentobjekt.

Dette gir klienter et alternativ til dagens opplastingsprosedyre, som har
et mellomsteg der arkivet er i en ufullstendig tilstand, mellom
oppretting av dokumentobjekt-instans og vellykket opplasting av
arkivfil, og kunne laste opp fil direkte fra dokumentbeskrivelse
i tillegg til fra dokumentobjekt. Når dokumentobjekt opprettes
automatisk brukes variantformat Produksjonsformat med mindre
API-tjenesten kjenner igjen et arkivformat.

Dette forslaget er basert på ideer i mangelmelding #25, og
Reduserer utfordringer omtalt i mangelmelding #285.