### PR TITLE
Fjernet tittel fra GET ny-*-eksempel

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.rst
+++ b/kapitler/06-konsepter_og_prinsipper.rst
@@ -701,7 +701,6 @@ hentes fra slik som mappetype og dokumentmedium.
            "kode": "BYGG",
            "kodenavn": "Byggesak"
        },
-       "tittel": "angi tittel på mappe",
        "dokumentmedium": {
            "kode": "E",
            "kodenavn": "Elektronisk arkiv"


### PR DESCRIPTION
Det vil svært sjeldent være mulig for API-implementasjonen å tilby en tittel som sannsynligvis er egnet for å beskrive instansen som skal opprettes, så det er et dårlig eksempel.