### PR TITLE
Klargjør offisielle forkortelser for Noark 5 og Noark 5 Tjenstegrensesnitt

### DIFF
--- a/kapitler/05-definisjoner.rst
+++ b/kapitler/05-definisjoner.rst
@@ -3,6 +3,10 @@ Definisjoner
 
 Noark – Norsk Arkivstandard
 
+N5 - Noark versjon 5
+
+N5TG - Noark versjon 5 Tjenestegrensesnitt (denne spesifikasjonen)
+
 UML – Unified Modeling Language
 
 REST – Representational State Transfer


### PR DESCRIPTION
I dag er det noen som bruker N5TG og andre som bruker N5WS om denne spesifikasjone.  Sistnevnte er også brukt om et SOAP-API.

For å øke sjansen for et enhetlig vokabular når en omtaler Noark 5 og Noark 5 Tjenestegrensesnitt, definer forkortelser. 'n5' er i bruk i eksempel-URLer i denne spesifikasjonsteksten.