### PR TITLE
Klargjør at Odata og filtering ikke er valgfritt.

### DIFF
--- a/kapitler/06-konsepter_og_prinsipper.rst
+++ b/kapitler/06-konsepter_og_prinsipper.rst
@@ -219,11 +219,15 @@ Finne objekter (Read)
 For filter skal syntaks fra OData standarden
 (https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html)
 benyttes. De ressurser som støtter filter skal annonserer dette under
-**\_links** med **templated=true** og parametre som kan brukes til dette i
-**href**. Feltet «templated» er valgfritt og verdien skal antas å være «false»
-hvis det ikke finnes. Typiske parametre er **$filter**, **$top**, **$skip**
-og **$orderby**. Alle lister med data bør støtte søk og filtrering. Ressurslisten
-i \_links er alfabetisk sortert på «rel»-feltet i henhold til ASCII-verdi.
+**\_links** med **templated=true** og parametre som kan brukes til
+dette i **href**.  Støtte for filtrering annonseres med feltet
+«templated».  De endepunkter som ikke støtter filtering trenger ikke
+oppgi feltet «templated» og feltverdien antas å være «false» når
+feltet ikke finnes.  Typiske parametre er **$filter**, **$top**,
+**$skip** og **$orderby**.  Alle lister med data skal støtte
+filtrering, jamfør kravlisten under.  Lister bør også støtte søk
+(**$search**).  Ressurslisten i \_links er alfabetisk sortert på
+«rel»-feltet i henhold til ASCII-verdi.
 
 .. code:: python
 


### PR DESCRIPTION
Lister skal støtte basis filtrering, kun utvidet filtrering og søk er valgfritt.

Fixes #303.